### PR TITLE
feat: implement console, refactor lifecycles slightly

### DIFF
--- a/demos/node/.vscode/launch.json
+++ b/demos/node/.vscode/launch.json
@@ -1,21 +1,34 @@
 {
-    // Use IntelliSense to learn about possible attributes.
-    // Hover to view descriptions of existing attributes.
-    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "pwa-node",
-            "request": "launch",
-            "name": "PWA: launch program",
-            "program": "${workspaceFolder}/main.js"
-        },
-        {
-          "type": "pwa-node",
-          "request": "launch",
-          "name": "PWA debug server",
-          "debugServer": 4711,
-          "program": "${workspaceFolder}/main.js"
-        }
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "[Node] Launch program",
+      "program": "${workspaceFolder}/main.js"
+    },
+    {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "[Node] Launch with Debug Server",
+      "debugServer": 4711,
+      "program": "${workspaceFolder}/main.js"
+    },
+    {
+      "type": "pwa-node",
+      "request": "launch",
+      "name": "[Node] Invalid Launch Program",
+      "program": "missing-file.js",
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "[Node] Launch Legacy Debug",
+      "console": "externalTerminal",
+      "program": "${workspaceFolder}/main.js"
+    }
   ]
 }

--- a/demos/node/.vscode/launch.json
+++ b/demos/node/.vscode/launch.json
@@ -13,6 +13,13 @@
     {
       "type": "pwa-node",
       "request": "launch",
+      "name": "[Node] Launch crashing program",
+      "restart": true,
+      "program": "${workspaceFolder}/crasher.js"
+    },
+    {
+      "type": "pwa-node",
+      "request": "launch",
       "name": "[Node] Launch with Debug Server",
       "debugServer": 4711,
       "program": "${workspaceFolder}/main.js"

--- a/demos/node/crasher.js
+++ b/demos/node/crasher.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+const desiredCrashes = 3;
+const crashFile = path.join(__dirname, 'crashes.txt');
+
+setTimeout(() => {
+  let crashes;
+  if (fs.existsSync(crashFile)) {
+    crashes = Number(fs.readFileSync(crashFile, 'utf-8'));
+  } else {
+    crashes = 0;
+  }
+
+  if (crashes < desiredCrashes) {
+    fs.writeFileSync(crashFile, String(crashes + 1));
+    console.error(`Crash #${crashes + 1}`);
+    process.exit(1);
+  } else {
+    fs.unlinkSync(crashFile);
+    console.log('Finished crashes, running now...');
+    debugger;
+    setInterval(() => undefined, 1000);
+  }
+}, 1000);

--- a/package.nls.json
+++ b/package.nls.json
@@ -38,6 +38,7 @@
   "node.address.description": "TCP/IP address of process to be debugged. Default is 'localhost'.",
   "node.attach.config.name": "Attach",
   "node.attach.processId.description": "ID of process to attach to.",
+  "node.console.title": "Node Debug Console",
   "node.disableOptimisticBPs.description": "Don't set breakpoints in any file until a sourcemap has been loaded for that file.",
   "node.label": "Node.js",
   "node.launch.autoAttachChildProcesses.description": "Attach debugger to new child processes automatically.",

--- a/scripts/generate-dap-api.js
+++ b/scripts/generate-dap-api.js
@@ -129,7 +129,7 @@ async function generate() {
       result.push(`    ${desc.properties.event.enum[0]}(params: ${name}Params): void;`);
       stubs.push({type: 'event', name: `${name}Params`, value: desc.properties.body || {properties: {}}});
     }
-    if (ref['$ref'] === '#/definitions/Request' && desc.title !== 'Reverse Requests') {
+    if (ref['$ref'] === '#/definitions/Request') {
       const short = desc.properties.command.enum[0];
       const title = toTitleCase(short);
       apiSeparator();
@@ -138,6 +138,9 @@ async function generate() {
       const args = desc.properties.arguments ? desc.properties.arguments['$ref'] : '#/definitions/';
       stubs.push({type: 'params', name: `${title}Params`, value: defs[definition(args)] || {properties: {}}});
       stubs.push({type: 'result', name: `${title}Result`, value: defs[`${name.substring(0, name.length - 'Request'.length)}Response`]});
+
+      appendText(desc.description, '    ');
+      result.push(`    ${short}Request(params: ${title}Params): Promise<${title}Result>;`);
     }
   }
   result.push(`  }`);
@@ -162,7 +165,7 @@ async function generate() {
         result.push(`    off(request: '${desc.properties.event.enum[0]}', handler: (params: ${name}Params) => void): void;`);
         result.push(`    once(request: '${desc.properties.event.enum[0]}', filter?: (event: ${name}Params) => boolean): Promise<${name}Params>;`);
       }
-      if (ref['$ref'] === '#/definitions/Request' && desc.title !== 'Reverse Requests') {
+      if (ref['$ref'] === '#/definitions/Request') {
         const short = desc.properties.command.enum[0];
         const title = toTitleCase(short);
         apiSeparator();

--- a/src/adapter/sources.ts
+++ b/src/adapter/sources.ts
@@ -10,6 +10,7 @@ import * as sourceUtils from '../common/sourceUtils';
 import { prettyPrintAsSourceMap } from '../common/sourceUtils';
 import * as utils from '../common/urlUtils';
 import * as errors from '../dap/errors';
+import { delay } from '../common/promiseUtil';
 
 const localize = nls.loadMessageBundle();
 
@@ -296,7 +297,7 @@ export class SourceContainer {
       const sourceMap = this._sourceMaps.get(uiLocation.source._sourceMapUrl)!;
       await Promise.race([
         sourceMap.loaded,
-        new Promise(f => setTimeout(f, this._sourceMapTimeouts.resolveLocation)),
+        delay(this._sourceMapTimeouts.resolveLocation),
       ]);
       if (!sourceMap.map)
         return uiLocation;

--- a/src/common/promiseUtil.ts
+++ b/src/common/promiseUtil.ts
@@ -1,0 +1,4 @@
+/**
+ * Returns a promise that resolves after the given time.
+ */
+export const delay = (duration: number) => new Promise<void>(resolve => setTimeout(resolve, duration));

--- a/src/common/sourceUtils.ts
+++ b/src/common/sourceUtils.ts
@@ -7,6 +7,7 @@ import * as ts from 'typescript';
 import * as urlUtils from './urlUtils';
 import * as fsUtils from './fsUtils';
 import { calculateHash } from './hash';
+import { delay } from './promiseUtil';
 
 export type SourceMapConsumer = sourceMap.BasicSourceMapConsumer | sourceMap.IndexedSourceMapConsumer;
 
@@ -193,7 +194,7 @@ export function wrapObjectLiteral(code: string): string {
 
 export async function loadSourceMap(url: string, slowDown: number): Promise<SourceMapConsumer | undefined> {
   if (slowDown)
-    await new Promise(f => setTimeout(f, slowDown));
+    await delay(slowDown);
   let content = await urlUtils.fetch(url);
   if (content.slice(0, 3) === ')]}')
     content = content.substring(content.indexOf('\n'));

--- a/src/dap/api.d.ts
+++ b/src/dap/api.d.ts
@@ -22,6 +22,16 @@ export namespace Dap {
      * Returning partial results from a cancelled request is possible but please note that a frontend client has no generic way for detecting that a response is partial or not.
      */
     on(request: 'cancel', handler: (params: CancelParams) => Promise<CancelResult | Error>): () => void;
+    /**
+     * The 'cancel' request is used by the frontend to indicate that it is no longer interested in the result produced by a specific request issued earlier.
+     * This request has a hint characteristic: a debug adapter can only be expected to make a 'best effort' in honouring this request but there are no guarantees.
+     * The 'cancel' request may return an error if it could not cancel an operation but a frontend should refrain from presenting this error to end users.
+     * A frontend client should only call this request if the capability 'supportsCancelRequest' is true.
+     * The request that got canceled still needs to send a response back.
+     * This can either be a normal result ('success' attribute true) or an error response ('success' attribute false and the 'message' set to 'cancelled').
+     * Returning partial results from a cancelled request is possible but please note that a frontend client has no generic way for detecting that a response is partial or not.
+     */
+    cancelRequest(params: CancelParams): Promise<CancelResult>;
 
     /**
      * This event indicates that the debug adapter is ready to accept configuration requests (e.g. SetBreakpointsRequest, SetExceptionBreakpointsRequest).
@@ -98,26 +108,53 @@ export namespace Dap {
     capabilities(params: CapabilitiesEventParams): void;
 
     /**
+     * This request is sent from the debug adapter to the client to run a command in a terminal. This is typically used to launch the debuggee in a terminal provided by the client.
+     */
+    on(request: 'runInTerminal', handler: (params: RunInTerminalParams) => Promise<RunInTerminalResult | Error>): () => void;
+    /**
+     * This request is sent from the debug adapter to the client to run a command in a terminal. This is typically used to launch the debuggee in a terminal provided by the client.
+     */
+    runInTerminalRequest(params: RunInTerminalParams): Promise<RunInTerminalResult>;
+
+    /**
      * The 'initialize' request is sent as the first request from the client to the debug adapter in order to configure it with client capabilities and to retrieve capabilities from the debug adapter.
      * Until the debug adapter has responded to with an 'initialize' response, the client must not send any additional requests or events to the debug adapter. In addition the debug adapter is not allowed to send any requests or events to the client until it has responded with an 'initialize' response.
      * The 'initialize' request may only be sent once.
      */
     on(request: 'initialize', handler: (params: InitializeParams) => Promise<InitializeResult | Error>): () => void;
+    /**
+     * The 'initialize' request is sent as the first request from the client to the debug adapter in order to configure it with client capabilities and to retrieve capabilities from the debug adapter.
+     * Until the debug adapter has responded to with an 'initialize' response, the client must not send any additional requests or events to the debug adapter. In addition the debug adapter is not allowed to send any requests or events to the client until it has responded with an 'initialize' response.
+     * The 'initialize' request may only be sent once.
+     */
+    initializeRequest(params: InitializeParams): Promise<InitializeResult>;
 
     /**
      * The client of the debug protocol must send this request at the end of the sequence of configuration requests (which was started by the 'initialized' event).
      */
     on(request: 'configurationDone', handler: (params: ConfigurationDoneParams) => Promise<ConfigurationDoneResult | Error>): () => void;
+    /**
+     * The client of the debug protocol must send this request at the end of the sequence of configuration requests (which was started by the 'initialized' event).
+     */
+    configurationDoneRequest(params: ConfigurationDoneParams): Promise<ConfigurationDoneResult>;
 
     /**
      * The launch request is sent from the client to the debug adapter to start the debuggee with or without debugging (if 'noDebug' is true). Since launching is debugger/runtime specific, the arguments for this request are not part of this specification.
      */
     on(request: 'launch', handler: (params: LaunchParams) => Promise<LaunchResult | Error>): () => void;
+    /**
+     * The launch request is sent from the client to the debug adapter to start the debuggee with or without debugging (if 'noDebug' is true). Since launching is debugger/runtime specific, the arguments for this request are not part of this specification.
+     */
+    launchRequest(params: LaunchParams): Promise<LaunchResult>;
 
     /**
      * The attach request is sent from the client to the debug adapter to attach to a debuggee that is already running. Since attaching is debugger/runtime specific, the arguments for this request are not part of this specification.
      */
     on(request: 'attach', handler: (params: AttachParams) => Promise<AttachResult | Error>): () => void;
+    /**
+     * The attach request is sent from the client to the debug adapter to attach to a debuggee that is already running. Since attaching is debugger/runtime specific, the arguments for this request are not part of this specification.
+     */
+    attachRequest(params: AttachParams): Promise<AttachResult>;
 
     /**
      * Restarts a debug session. If the capability 'supportsRestartRequest' is missing or has the value false,
@@ -126,21 +163,40 @@ export namespace Dap {
      * and setting the capability 'supportsRestartRequest' to true.
      */
     on(request: 'restart', handler: (params: RestartParams) => Promise<RestartResult | Error>): () => void;
+    /**
+     * Restarts a debug session. If the capability 'supportsRestartRequest' is missing or has the value false,
+     * the client will implement 'restart' by terminating the debug adapter first and then launching it anew.
+     * A debug adapter can override this default behaviour by implementing a restart request
+     * and setting the capability 'supportsRestartRequest' to true.
+     */
+    restartRequest(params: RestartParams): Promise<RestartResult>;
 
     /**
      * The 'disconnect' request is sent from the client to the debug adapter in order to stop debugging. It asks the debug adapter to disconnect from the debuggee and to terminate the debug adapter. If the debuggee has been started with the 'launch' request, the 'disconnect' request terminates the debuggee. If the 'attach' request was used to connect to the debuggee, 'disconnect' does not terminate the debuggee. This behavior can be controlled with the 'terminateDebuggee' argument (if supported by the debug adapter).
      */
     on(request: 'disconnect', handler: (params: DisconnectParams) => Promise<DisconnectResult | Error>): () => void;
+    /**
+     * The 'disconnect' request is sent from the client to the debug adapter in order to stop debugging. It asks the debug adapter to disconnect from the debuggee and to terminate the debug adapter. If the debuggee has been started with the 'launch' request, the 'disconnect' request terminates the debuggee. If the 'attach' request was used to connect to the debuggee, 'disconnect' does not terminate the debuggee. This behavior can be controlled with the 'terminateDebuggee' argument (if supported by the debug adapter).
+     */
+    disconnectRequest(params: DisconnectParams): Promise<DisconnectResult>;
 
     /**
      * The 'terminate' request is sent from the client to the debug adapter in order to give the debuggee a chance for terminating itself.
      */
     on(request: 'terminate', handler: (params: TerminateParams) => Promise<TerminateResult | Error>): () => void;
+    /**
+     * The 'terminate' request is sent from the client to the debug adapter in order to give the debuggee a chance for terminating itself.
+     */
+    terminateRequest(params: TerminateParams): Promise<TerminateResult>;
 
     /**
      * The 'breakpointLocations' request returns all possible locations for source breakpoints in a given range.
      */
     on(request: 'breakpointLocations', handler: (params: BreakpointLocationsParams) => Promise<BreakpointLocationsResult | Error>): () => void;
+    /**
+     * The 'breakpointLocations' request returns all possible locations for source breakpoints in a given range.
+     */
+    breakpointLocationsRequest(params: BreakpointLocationsParams): Promise<BreakpointLocationsResult>;
 
     /**
      * Sets multiple breakpoints for a single source and clears all previous breakpoints in that source.
@@ -148,6 +204,12 @@ export namespace Dap {
      * When a breakpoint is hit, a 'stopped' event (with reason 'breakpoint') is generated.
      */
     on(request: 'setBreakpoints', handler: (params: SetBreakpointsParams) => Promise<SetBreakpointsResult | Error>): () => void;
+    /**
+     * Sets multiple breakpoints for a single source and clears all previous breakpoints in that source.
+     * To clear all breakpoint for a source, specify an empty array.
+     * When a breakpoint is hit, a 'stopped' event (with reason 'breakpoint') is generated.
+     */
+    setBreakpointsRequest(params: SetBreakpointsParams): Promise<SetBreakpointsResult>;
 
     /**
      * Replaces all existing function breakpoints with new function breakpoints.
@@ -155,16 +217,30 @@ export namespace Dap {
      * When a function breakpoint is hit, a 'stopped' event (with reason 'function breakpoint') is generated.
      */
     on(request: 'setFunctionBreakpoints', handler: (params: SetFunctionBreakpointsParams) => Promise<SetFunctionBreakpointsResult | Error>): () => void;
+    /**
+     * Replaces all existing function breakpoints with new function breakpoints.
+     * To clear all function breakpoints, specify an empty array.
+     * When a function breakpoint is hit, a 'stopped' event (with reason 'function breakpoint') is generated.
+     */
+    setFunctionBreakpointsRequest(params: SetFunctionBreakpointsParams): Promise<SetFunctionBreakpointsResult>;
 
     /**
      * The request configures the debuggers response to thrown exceptions. If an exception is configured to break, a 'stopped' event is fired (with reason 'exception').
      */
     on(request: 'setExceptionBreakpoints', handler: (params: SetExceptionBreakpointsParams) => Promise<SetExceptionBreakpointsResult | Error>): () => void;
+    /**
+     * The request configures the debuggers response to thrown exceptions. If an exception is configured to break, a 'stopped' event is fired (with reason 'exception').
+     */
+    setExceptionBreakpointsRequest(params: SetExceptionBreakpointsParams): Promise<SetExceptionBreakpointsResult>;
 
     /**
      * Obtains information on a possible data breakpoint that could be set on an expression or variable.
      */
     on(request: 'dataBreakpointInfo', handler: (params: DataBreakpointInfoParams) => Promise<DataBreakpointInfoResult | Error>): () => void;
+    /**
+     * Obtains information on a possible data breakpoint that could be set on an expression or variable.
+     */
+    dataBreakpointInfoRequest(params: DataBreakpointInfoParams): Promise<DataBreakpointInfoResult>;
 
     /**
      * Replaces all existing data breakpoints with new data breakpoints.
@@ -172,17 +248,32 @@ export namespace Dap {
      * When a data breakpoint is hit, a 'stopped' event (with reason 'data breakpoint') is generated.
      */
     on(request: 'setDataBreakpoints', handler: (params: SetDataBreakpointsParams) => Promise<SetDataBreakpointsResult | Error>): () => void;
+    /**
+     * Replaces all existing data breakpoints with new data breakpoints.
+     * To clear all data breakpoints, specify an empty array.
+     * When a data breakpoint is hit, a 'stopped' event (with reason 'data breakpoint') is generated.
+     */
+    setDataBreakpointsRequest(params: SetDataBreakpointsParams): Promise<SetDataBreakpointsResult>;
 
     /**
      * The request starts the debuggee to run again.
      */
     on(request: 'continue', handler: (params: ContinueParams) => Promise<ContinueResult | Error>): () => void;
+    /**
+     * The request starts the debuggee to run again.
+     */
+    continueRequest(params: ContinueParams): Promise<ContinueResult>;
 
     /**
      * The request starts the debuggee to run again for one step.
      * The debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.
      */
     on(request: 'next', handler: (params: NextParams) => Promise<NextResult | Error>): () => void;
+    /**
+     * The request starts the debuggee to run again for one step.
+     * The debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.
+     */
+    nextRequest(params: NextParams): Promise<NextResult>;
 
     /**
      * The request starts the debuggee to step into a function/method if possible.
@@ -193,29 +284,57 @@ export namespace Dap {
      * The list of possible targets for a given source line can be retrieved via the 'stepInTargets' request.
      */
     on(request: 'stepIn', handler: (params: StepInParams) => Promise<StepInResult | Error>): () => void;
+    /**
+     * The request starts the debuggee to step into a function/method if possible.
+     * If it cannot step into a target, 'stepIn' behaves like 'next'.
+     * The debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.
+     * If there are multiple function/method calls (or other targets) on the source line,
+     * the optional argument 'targetId' can be used to control into which target the 'stepIn' should occur.
+     * The list of possible targets for a given source line can be retrieved via the 'stepInTargets' request.
+     */
+    stepInRequest(params: StepInParams): Promise<StepInResult>;
 
     /**
      * The request starts the debuggee to run again for one step.
      * The debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.
      */
     on(request: 'stepOut', handler: (params: StepOutParams) => Promise<StepOutResult | Error>): () => void;
+    /**
+     * The request starts the debuggee to run again for one step.
+     * The debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed.
+     */
+    stepOutRequest(params: StepOutParams): Promise<StepOutResult>;
 
     /**
      * The request starts the debuggee to run one step backwards.
      * The debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed. Clients should only call this request if the capability 'supportsStepBack' is true.
      */
     on(request: 'stepBack', handler: (params: StepBackParams) => Promise<StepBackResult | Error>): () => void;
+    /**
+     * The request starts the debuggee to run one step backwards.
+     * The debug adapter first sends the response and then a 'stopped' event (with reason 'step') after the step has completed. Clients should only call this request if the capability 'supportsStepBack' is true.
+     */
+    stepBackRequest(params: StepBackParams): Promise<StepBackResult>;
 
     /**
      * The request starts the debuggee to run backward. Clients should only call this request if the capability 'supportsStepBack' is true.
      */
     on(request: 'reverseContinue', handler: (params: ReverseContinueParams) => Promise<ReverseContinueResult | Error>): () => void;
+    /**
+     * The request starts the debuggee to run backward. Clients should only call this request if the capability 'supportsStepBack' is true.
+     */
+    reverseContinueRequest(params: ReverseContinueParams): Promise<ReverseContinueResult>;
 
     /**
      * The request restarts execution of the specified stackframe.
      * The debug adapter first sends the response and then a 'stopped' event (with reason 'restart') after the restart has completed.
      */
     on(request: 'restartFrame', handler: (params: RestartFrameParams) => Promise<RestartFrameResult | Error>): () => void;
+    /**
+     * The request restarts execution of the specified stackframe.
+     * The debug adapter first sends the response and then a 'stopped' event (with reason 'restart') after the restart has completed.
+     */
+    restartFrameRequest(params: RestartFrameParams): Promise<RestartFrameResult>;
 
     /**
      * The request sets the location where the debuggee will continue to run.
@@ -224,70 +343,129 @@ export namespace Dap {
      * The debug adapter first sends the response and then a 'stopped' event with reason 'goto'.
      */
     on(request: 'goto', handler: (params: GotoParams) => Promise<GotoResult | Error>): () => void;
+    /**
+     * The request sets the location where the debuggee will continue to run.
+     * This makes it possible to skip the execution of code or to executed code again.
+     * The code between the current location and the goto target is not executed but skipped.
+     * The debug adapter first sends the response and then a 'stopped' event with reason 'goto'.
+     */
+    gotoRequest(params: GotoParams): Promise<GotoResult>;
 
     /**
      * The request suspends the debuggee.
      * The debug adapter first sends the response and then a 'stopped' event (with reason 'pause') after the thread has been paused successfully.
      */
     on(request: 'pause', handler: (params: PauseParams) => Promise<PauseResult | Error>): () => void;
+    /**
+     * The request suspends the debuggee.
+     * The debug adapter first sends the response and then a 'stopped' event (with reason 'pause') after the thread has been paused successfully.
+     */
+    pauseRequest(params: PauseParams): Promise<PauseResult>;
 
     /**
      * The request returns a stacktrace from the current execution state.
      */
     on(request: 'stackTrace', handler: (params: StackTraceParams) => Promise<StackTraceResult | Error>): () => void;
+    /**
+     * The request returns a stacktrace from the current execution state.
+     */
+    stackTraceRequest(params: StackTraceParams): Promise<StackTraceResult>;
 
     /**
      * The request returns the variable scopes for a given stackframe ID.
      */
     on(request: 'scopes', handler: (params: ScopesParams) => Promise<ScopesResult | Error>): () => void;
+    /**
+     * The request returns the variable scopes for a given stackframe ID.
+     */
+    scopesRequest(params: ScopesParams): Promise<ScopesResult>;
 
     /**
      * Retrieves all child variables for the given variable reference.
      * An optional filter can be used to limit the fetched children to either named or indexed children.
      */
     on(request: 'variables', handler: (params: VariablesParams) => Promise<VariablesResult | Error>): () => void;
+    /**
+     * Retrieves all child variables for the given variable reference.
+     * An optional filter can be used to limit the fetched children to either named or indexed children.
+     */
+    variablesRequest(params: VariablesParams): Promise<VariablesResult>;
 
     /**
      * Set the variable with the given name in the variable container to a new value.
      */
     on(request: 'setVariable', handler: (params: SetVariableParams) => Promise<SetVariableResult | Error>): () => void;
+    /**
+     * Set the variable with the given name in the variable container to a new value.
+     */
+    setVariableRequest(params: SetVariableParams): Promise<SetVariableResult>;
 
     /**
      * The request retrieves the source code for a given source reference.
      */
     on(request: 'source', handler: (params: SourceParams) => Promise<SourceResult | Error>): () => void;
+    /**
+     * The request retrieves the source code for a given source reference.
+     */
+    sourceRequest(params: SourceParams): Promise<SourceResult>;
 
     /**
      * The request retrieves a list of all threads.
      */
     on(request: 'threads', handler: (params: ThreadsParams) => Promise<ThreadsResult | Error>): () => void;
+    /**
+     * The request retrieves a list of all threads.
+     */
+    threadsRequest(params: ThreadsParams): Promise<ThreadsResult>;
 
     /**
      * The request terminates the threads with the given ids.
      */
     on(request: 'terminateThreads', handler: (params: TerminateThreadsParams) => Promise<TerminateThreadsResult | Error>): () => void;
+    /**
+     * The request terminates the threads with the given ids.
+     */
+    terminateThreadsRequest(params: TerminateThreadsParams): Promise<TerminateThreadsResult>;
 
     /**
      * Modules can be retrieved from the debug adapter with the ModulesRequest which can either return all modules or a range of modules to support paging.
      */
     on(request: 'modules', handler: (params: ModulesParams) => Promise<ModulesResult | Error>): () => void;
+    /**
+     * Modules can be retrieved from the debug adapter with the ModulesRequest which can either return all modules or a range of modules to support paging.
+     */
+    modulesRequest(params: ModulesParams): Promise<ModulesResult>;
 
     /**
      * Retrieves the set of all sources currently loaded by the debugged process.
      */
     on(request: 'loadedSources', handler: (params: LoadedSourcesParams) => Promise<LoadedSourcesResult | Error>): () => void;
+    /**
+     * Retrieves the set of all sources currently loaded by the debugged process.
+     */
+    loadedSourcesRequest(params: LoadedSourcesParams): Promise<LoadedSourcesResult>;
 
     /**
      * Evaluates the given expression in the context of the top most stack frame.
      * The expression has access to any variables and arguments that are in scope.
      */
     on(request: 'evaluate', handler: (params: EvaluateParams) => Promise<EvaluateResult | Error>): () => void;
+    /**
+     * Evaluates the given expression in the context of the top most stack frame.
+     * The expression has access to any variables and arguments that are in scope.
+     */
+    evaluateRequest(params: EvaluateParams): Promise<EvaluateResult>;
 
     /**
      * Evaluates the given 'value' expression and assigns it to the 'expression' which must be a modifiable l-value.
      * The expressions have access to any variables and arguments that are in scope of the specified frame.
      */
     on(request: 'setExpression', handler: (params: SetExpressionParams) => Promise<SetExpressionResult | Error>): () => void;
+    /**
+     * Evaluates the given 'value' expression and assigns it to the 'expression' which must be a modifiable l-value.
+     * The expressions have access to any variables and arguments that are in scope of the specified frame.
+     */
+    setExpressionRequest(params: SetExpressionParams): Promise<SetExpressionResult>;
 
     /**
      * This request retrieves the possible stepIn targets for the specified stack frame.
@@ -295,6 +473,12 @@ export namespace Dap {
      * The StepInTargets may only be called if the 'supportsStepInTargetsRequest' capability exists and is true.
      */
     on(request: 'stepInTargets', handler: (params: StepInTargetsParams) => Promise<StepInTargetsResult | Error>): () => void;
+    /**
+     * This request retrieves the possible stepIn targets for the specified stack frame.
+     * These targets can be used in the 'stepIn' request.
+     * The StepInTargets may only be called if the 'supportsStepInTargetsRequest' capability exists and is true.
+     */
+    stepInTargetsRequest(params: StepInTargetsParams): Promise<StepInTargetsResult>;
 
     /**
      * This request retrieves the possible goto targets for the specified source location.
@@ -302,47 +486,86 @@ export namespace Dap {
      * The GotoTargets request may only be called if the 'supportsGotoTargetsRequest' capability exists and is true.
      */
     on(request: 'gotoTargets', handler: (params: GotoTargetsParams) => Promise<GotoTargetsResult | Error>): () => void;
+    /**
+     * This request retrieves the possible goto targets for the specified source location.
+     * These targets can be used in the 'goto' request.
+     * The GotoTargets request may only be called if the 'supportsGotoTargetsRequest' capability exists and is true.
+     */
+    gotoTargetsRequest(params: GotoTargetsParams): Promise<GotoTargetsResult>;
 
     /**
      * Returns a list of possible completions for a given caret position and text.
      * The CompletionsRequest may only be called if the 'supportsCompletionsRequest' capability exists and is true.
      */
     on(request: 'completions', handler: (params: CompletionsParams) => Promise<CompletionsResult | Error>): () => void;
+    /**
+     * Returns a list of possible completions for a given caret position and text.
+     * The CompletionsRequest may only be called if the 'supportsCompletionsRequest' capability exists and is true.
+     */
+    completionsRequest(params: CompletionsParams): Promise<CompletionsResult>;
 
     /**
      * Retrieves the details of the exception that caused this event to be raised.
      */
     on(request: 'exceptionInfo', handler: (params: ExceptionInfoParams) => Promise<ExceptionInfoResult | Error>): () => void;
+    /**
+     * Retrieves the details of the exception that caused this event to be raised.
+     */
+    exceptionInfoRequest(params: ExceptionInfoParams): Promise<ExceptionInfoResult>;
 
     /**
      * Reads bytes from memory at the provided location.
      */
     on(request: 'readMemory', handler: (params: ReadMemoryParams) => Promise<ReadMemoryResult | Error>): () => void;
+    /**
+     * Reads bytes from memory at the provided location.
+     */
+    readMemoryRequest(params: ReadMemoryParams): Promise<ReadMemoryResult>;
 
     /**
      * Disassembles code stored at the provided location.
      */
     on(request: 'disassemble', handler: (params: DisassembleParams) => Promise<DisassembleResult | Error>): () => void;
+    /**
+     * Disassembles code stored at the provided location.
+     */
+    disassembleRequest(params: DisassembleParams): Promise<DisassembleResult>;
 
     /**
      * Enable custom breakpoints.
      */
     on(request: 'enableCustomBreakpoints', handler: (params: EnableCustomBreakpointsParams) => Promise<EnableCustomBreakpointsResult | Error>): () => void;
+    /**
+     * Enable custom breakpoints.
+     */
+    enableCustomBreakpointsRequest(params: EnableCustomBreakpointsParams): Promise<EnableCustomBreakpointsResult>;
 
     /**
      * Disable custom breakpoints.
      */
     on(request: 'disableCustomBreakpoints', handler: (params: DisableCustomBreakpointsParams) => Promise<DisableCustomBreakpointsResult | Error>): () => void;
+    /**
+     * Disable custom breakpoints.
+     */
+    disableCustomBreakpointsRequest(params: DisableCustomBreakpointsParams): Promise<DisableCustomBreakpointsResult>;
 
     /**
      * Returns whether particular source can be pretty-printed.
      */
     on(request: 'canPrettyPrintSource', handler: (params: CanPrettyPrintSourceParams) => Promise<CanPrettyPrintSourceResult | Error>): () => void;
+    /**
+     * Returns whether particular source can be pretty-printed.
+     */
+    canPrettyPrintSourceRequest(params: CanPrettyPrintSourceParams): Promise<CanPrettyPrintSourceResult>;
 
     /**
      * Pretty prints source for debugging.
      */
     on(request: 'prettyPrintSource', handler: (params: PrettyPrintSourceParams) => Promise<PrettyPrintSourceResult | Error>): () => void;
+    /**
+     * Pretty prints source for debugging.
+     */
+    prettyPrintSourceRequest(params: PrettyPrintSourceParams): Promise<PrettyPrintSourceResult>;
 
     /**
      * A request to reveal a certain location in the UI.
@@ -465,6 +688,11 @@ export namespace Dap {
     on(request: 'capabilities', handler: (params: CapabilitiesEventParams) => void): void;
     off(request: 'capabilities', handler: (params: CapabilitiesEventParams) => void): void;
     once(request: 'capabilities', filter?: (event: CapabilitiesEventParams) => boolean): Promise<CapabilitiesEventParams>;
+
+    /**
+     * This request is sent from the debug adapter to the client to run a command in a terminal. This is typically used to launch the debuggee in a terminal provided by the client.
+     */
+    runInTerminal(params: RunInTerminalParams): Promise<RunInTerminalResult>;
 
     /**
      * The 'initialize' request is sent as the first request from the client to the debug adapter in order to configure it with client capabilities and to retrieve capabilities from the debug adapter.
@@ -1602,6 +1830,45 @@ export namespace Dap {
   }
 
   export interface ReverseContinueResult {
+  }
+
+  export interface RunInTerminalParams {
+    /**
+     * What kind of terminal to launch.
+     */
+    kind?: string;
+
+    /**
+     * Optional title of the terminal.
+     */
+    title?: string;
+
+    /**
+     * Working directory of the command.
+     */
+    cwd: string;
+
+    /**
+     * List of arguments. The first argument is the command to run.
+     */
+    args: string[];
+
+    /**
+     * Environment key-value pairs that are added to or removed from the default environment.
+     */
+    env?: object;
+  }
+
+  export interface RunInTerminalResult {
+    /**
+     * The process ID. The value should be less than or equal to 2147483647 (2^31 - 1).
+     */
+    processId?: integer;
+
+    /**
+     * The process ID of the terminal shell. The value should be less than or equal to 2147483647 (2^31 - 1).
+     */
+    shellProcessId?: integer;
   }
 
   export interface ScopesParams {

--- a/src/dap/errors.ts
+++ b/src/dap/errors.ts
@@ -11,6 +11,8 @@ export const enum ErrorCodes {
   UserError,
   NvmNotFound,
   NvmHomeNotFound,
+  CannotLaunchInTerminal,
+  CannotLoadEnvironmentVariables
 }
 
 export function reportToConsole(dap: Dap.Api, error: string) {
@@ -69,6 +71,18 @@ export const nvmVersionNotFound = (version: string, versionManager: string) =>
       versionManager,
     ),
     ErrorCodes.NvmHomeNotFound,
+  );
+
+export const cannotLaunchInTerminal = (errorMessage: string) =>
+  createUserError(
+    localize('VSND2011', 'Cannot launch debug target in terminal ({0}).', errorMessage),
+    ErrorCodes.CannotLaunchInTerminal,
+  );
+
+export const cannotLoadEnvironmentVars = (errorMessage: string) =>
+  createUserError(
+    localize('VSND2029', "Can't load environment variables from file ({0}).", errorMessage),
+    ErrorCodes.CannotLoadEnvironmentVariables,
   );
 
 export class ProtocolError extends Error {

--- a/src/debugServer.ts
+++ b/src/debugServer.ts
@@ -14,6 +14,7 @@ import { Target } from './targets/targets';
 import { DebugAdapter } from './adapter/debugAdapter';
 import Dap from './dap/api';
 import { generateBreakpointIds } from './adapter/breakpoints';
+import { SubprocessProgramLauncher } from './targets/node/subprocessProgramLauncher';
 import { TerminalProgramLauncher } from './targets/node/terminalProgramLauncher';
 
 const storagePath = fs.mkdtempSync(path.join(os.tmpdir(), 'pwa-debugger-'));
@@ -78,7 +79,7 @@ class Configurator {
 
 const server = net.createServer(async socket => {
   const launchers = [
-    new NodeLauncher(new TerminalProgramLauncher()),
+    new NodeLauncher([new SubprocessProgramLauncher(), new TerminalProgramLauncher()]),
     new BrowserLauncher(storagePath),
     new BrowserAttacher(),
   ];

--- a/src/flatSessionLauncher.ts
+++ b/src/flatSessionLauncher.ts
@@ -21,8 +21,9 @@ import { DebugAdapter } from './adapter/debugAdapter';
 import * as crypto from 'crypto';
 import { MessageEmitterConnection, ChildConnection } from './dap/flatSessionConnection';
 import { Disposable } from './common/events';
-import { TerminalProgramLauncher } from './targets/node/terminalProgramLauncher';
+import { SubprocessProgramLauncher } from './targets/node/subprocessProgramLauncher';
 import { Contributions } from './common/contributionUtils';
+import { TerminalProgramLauncher } from './targets/node/terminalProgramLauncher';
 
 const storagePath = fs.mkdtempSync(path.join(os.tmpdir(), 'pwa-debugger-'));
 
@@ -47,7 +48,7 @@ function main(inputStream: NodeJS.ReadableStream, outputStream: NodeJS.WritableS
 
   const _childSessionsForTarget = new Map<Target, ChildSession>();
   const launchers = [
-    new NodeLauncher(new TerminalProgramLauncher()),
+    new NodeLauncher([new SubprocessProgramLauncher(), new TerminalProgramLauncher()]),
     new BrowserLauncher(storagePath),
     new BrowserAttacher(),
   ];

--- a/src/targets/browser/browserAttacher.ts
+++ b/src/targets/browser/browserAttacher.ts
@@ -5,7 +5,7 @@ import { Disposable, EventEmitter } from '../../common/events';
 import CdpConnection from '../../cdp/connection';
 import * as launcher from './launcher';
 import { BrowserTarget, BrowserTargetManager } from './browserTargets';
-import { Target, Launcher, LaunchResult, ILaunchContext } from '../targets';
+import { Target, Launcher, LaunchResult, ILaunchContext, IStopMetadata } from '../targets';
 import { BrowserSourcePathResolver } from './browserPathResolver';
 import { baseURL } from './browserLaunchParams';
 import { AnyLaunchConfiguration, IChromeAttachConfiguration } from '../../configuration';
@@ -18,7 +18,7 @@ export class BrowserAttacher implements Launcher {
   private _launchParams: IChromeAttachConfiguration | undefined;
   private _targetOrigin: any;
   private _disposables: Disposable[] = [];
-  private _onTerminatedEmitter = new EventEmitter<void>();
+  private _onTerminatedEmitter = new EventEmitter<IStopMetadata>();
   readonly onTerminated = this._onTerminatedEmitter.event;
   private _onTargetListChangedEmitter = new EventEmitter<void>();
   readonly onTargetListChanged = this._onTargetListChangedEmitter.event;

--- a/src/targets/browser/browserLauncher.ts
+++ b/src/targets/browser/browserLauncher.ts
@@ -9,7 +9,7 @@ import CdpConnection from '../../cdp/connection';
 import findBrowser from './findBrowser';
 import * as launcher from './launcher';
 import { BrowserTarget, BrowserTargetManager } from './browserTargets';
-import { Target, Launcher, LaunchResult, ILaunchContext } from '../../targets/targets';
+import { Target, Launcher, LaunchResult, ILaunchContext, IStopMetadata } from '../../targets/targets';
 import { BrowserSourcePathResolver } from './browserPathResolver';
 import { baseURL } from './browserLaunchParams';
 import { AnyChromeConfiguration, IChromeLaunchConfiguration } from '../../configuration';
@@ -25,7 +25,7 @@ export class BrowserLauncher implements Launcher {
   private _launchParams: IChromeLaunchConfiguration | undefined;
   private _mainTarget?: BrowserTarget;
   private _disposables: Disposable[] = [];
-  private _onTerminatedEmitter = new EventEmitter<void>();
+  private _onTerminatedEmitter = new EventEmitter<IStopMetadata>();
   readonly onTerminated = this._onTerminatedEmitter.event;
   private _onTargetListChangedEmitter = new EventEmitter<void>();
   readonly onTargetListChanged = this._onTargetListChangedEmitter.event;
@@ -98,7 +98,7 @@ export class BrowserLauncher implements Launcher {
     if (params.logging && params.logging.cdp)
       connection.setLogConfig(params.url || '', params.logging.cdp);
     connection.onDisconnected(() => {
-      this._onTerminatedEmitter.fire();
+      this._onTerminatedEmitter.fire({ code: 0, killed: true });
     }, undefined, this._disposables);
     this._connectionForTest = connection;
     this._launchParams = params;
@@ -130,7 +130,7 @@ export class BrowserLauncher implements Launcher {
       return localize('error.threadNotFound', 'Target page not found');
     this._targetManager.onTargetRemoved((target: BrowserTarget) => {
       if (target === this._mainTarget)
-        this._onTerminatedEmitter.fire();
+        this._onTerminatedEmitter.fire({ code: 0, killed: true });
     });
     return this._mainTarget;
   }

--- a/src/targets/node/bootloader.ts
+++ b/src/targets/node/bootloader.ts
@@ -4,6 +4,7 @@
 import { spawn } from 'child_process';
 import * as inspector from 'inspector';
 import * as path from 'path';
+import { writeFileSync } from 'fs';
 
 function debugLog(text: string) {
   // require('fs').appendFileSync(require('path').join(require('os').homedir(), 'bootloader.txt'), `BOOTLOADER [${process.pid}] ${text}\n`);
@@ -11,16 +12,14 @@ function debugLog(text: string) {
 
 (function() {
   debugLog('args: ' + process.argv.join(' '));
-  if (!process.env.NODE_INSPECTOR_IPC)
-    return;
+  if (!process.env.NODE_INSPECTOR_IPC) return;
 
   // Electron support
   // Do not enable for Electron and other hybrid environments.
   try {
     eval('window');
     return;
-  } catch (e) {
-  }
+  } catch (e) {}
 
   // If we wanted to only debug the entrypoint, unset environment variables
   // so that nested processes do not inherit them.
@@ -28,29 +27,38 @@ function debugLog(text: string) {
     process.env.NODE_OPTIONS = undefined;
   }
 
+  if (process.env.VSCODE_DEBUGGER_FILE_CALLBACK) {
+    writeFileSync(
+      process.env.VSCODE_DEBUGGER_FILE_CALLBACK,
+      JSON.stringify({
+        processId: process.pid,
+        nodeVersion: process.version,
+        architecture: process.arch,
+      }),
+    );
+    delete process.env.VSCODE_DEBUGGER_FILE_CALLBACK;
+  }
+
   // Do not run watchdog using electron executable, stick with the cli's one.
-  if (process.execPath.endsWith('node'))
-    process.env.NODE_INSPECTOR_EXEC_PATH = process.execPath;
+  if (process.execPath.endsWith('node')) process.env.NODE_INSPECTOR_EXEC_PATH = process.execPath;
 
   let scriptName = '';
   try {
     scriptName = require.resolve(process.argv[1]);
-  } catch (e) {
-  }
+  } catch (e) {}
 
   let waitForDebugger = true;
   try {
-    waitForDebugger = new RegExp(process.env.NODE_INSPECTOR_WAIT_FOR_DEBUGGER || '').test(scriptName);
-  } catch (e) {
-  }
+    waitForDebugger = new RegExp(process.env.NODE_INSPECTOR_WAIT_FOR_DEBUGGER || '').test(
+      scriptName,
+    );
+  } catch (e) {}
 
-  if (!waitForDebugger)
-    return;
+  if (!waitForDebugger) return;
 
   const kBootloader = path.sep + 'bootloader.js';
   const kWatchdog = path.sep + 'watchdog.js';
-  if (!__filename.endsWith(kBootloader))
-    return;
+  if (!__filename.endsWith(kBootloader)) return;
   const fileName = __filename.substring(0, __filename.length - kBootloader.length) + kWatchdog;
 
   const ppid = process.env.NODE_INSPECTOR_PPID || '';
@@ -69,7 +77,7 @@ function debugLog(text: string) {
     scriptName,
     inspectorURL: inspector.url(),
     waitForDebugger,
-    ppid
+    ppid,
   };
 
   debugLog('Info: ' + JSON.stringify(info));
@@ -79,10 +87,10 @@ function debugLog(text: string) {
   const p = spawn(execPath, [fileName], {
     env: {
       NODE_INSPECTOR_INFO: JSON.stringify(info),
-      NODE_INSPECTOR_IPC: process.env.NODE_INSPECTOR_IPC
+      NODE_INSPECTOR_IPC: process.env.NODE_INSPECTOR_IPC,
     },
     stdio: 'ignore',
-    detached: true
+    detached: true,
   });
   p.unref();
   process.on('exit', () => p.kill());

--- a/src/targets/node/callback-file.ts
+++ b/src/targets/node/callback-file.ts
@@ -46,6 +46,8 @@ export class CallbackFile<T> implements Disposable {
           resolve(JSON.parse(readFileSync(this.path, 'utf-8')));
         } catch (e) {
           reject(e);
+        } finally {
+          this.dispose();
         }
 
         clearInterval(interval);
@@ -59,6 +61,10 @@ export class CallbackFile<T> implements Disposable {
    * Diposes of the callback file.
    */
   public dispose() {
+    if (this.disposed) {
+      return;
+    }
+
     this.disposed = true;
     try {
       unlinkSync(this.path);

--- a/src/targets/node/callback-file.ts
+++ b/src/targets/node/callback-file.ts
@@ -1,0 +1,69 @@
+import * as path from 'path';
+import { tmpdir } from 'os';
+import { randomBytes } from 'crypto';
+import { Disposable } from '../../common/events';
+import { unlinkSync, existsSync, readFileSync } from 'fs';
+
+/**
+ * File written by the bootloader containing some process information.
+ */
+export class CallbackFile<T> implements Disposable {
+  private static readonly pollInterval = 200;
+
+  /**
+   * Path of the callback file.
+   */
+  public readonly path = path.join(
+    tmpdir(),
+    `node-debug-callback-${randomBytes(8).toString('hex')}`,
+  );
+
+  private disposed = false;
+  private readPromise?: Promise<T | undefined>;
+
+  /**
+   * Reads the file, returnings its contants after they're written, or returns
+   * undefined if the file was disposed of before the read completed.
+   */
+  public read(pollInterval = CallbackFile.pollInterval) {
+    if (this.readPromise) {
+      return this.readPromise;
+    }
+
+    this.readPromise = new Promise<T>((resolve, reject) => {
+      const interval = setInterval(() => {
+        if (this.disposed) {
+          clearInterval(interval);
+          resolve(undefined);
+          return;
+        }
+
+        if (!existsSync(this.path)) {
+          return;
+        }
+
+        try {
+          resolve(JSON.parse(readFileSync(this.path, 'utf-8')));
+        } catch (e) {
+          reject(e);
+        }
+
+        clearInterval(interval);
+      }, pollInterval);
+    });
+
+    return this.readPromise;
+  }
+
+  /**
+   * Diposes of the callback file.
+   */
+  public dispose() {
+    this.disposed = true;
+    try {
+      unlinkSync(this.path);
+    } catch {
+      // ignored
+    }
+  }
+}

--- a/src/targets/node/killTree.ts
+++ b/src/targets/node/killTree.ts
@@ -1,0 +1,29 @@
+import { spawnSync, execSync } from 'child_process';
+import { join } from 'path';
+
+/**
+ * Kills the tree of processes starting at the given parent ID.
+ */
+export function killTree(processId: number): void {
+  if (process.platform === 'win32') {
+    const windir = process.env['WINDIR'] || 'C:\\Windows';
+    const TASK_KILL = join(windir, 'System32', 'taskkill.exe');
+
+    // when killing a process in Windows its child processes are *not* killed but become root processes.
+    // Therefore we use TASKKILL.EXE
+    try {
+      execSync(`${TASK_KILL} /F /T /PID ${processId}`);
+    } catch (err) {
+      // ignored
+    }
+  } else {
+    // on linux and OS X we kill all direct and indirect child processes as well
+    try {
+      const cmd = join(__dirname, './terminateProcess.sh');
+      spawnSync(cmd, [processId.toString()]);
+    } catch (err) {
+      console.log(err);
+      // ignored
+    }
+  }
+}

--- a/src/targets/node/processLauncher.ts
+++ b/src/targets/node/processLauncher.ts
@@ -3,31 +3,50 @@
 
 import * as path from 'path';
 import * as nls from 'vscode-nls';
-import * as fs from 'fs';
-import { IProgramLauncher } from './nodeLauncher';
-import { EventEmitter } from '../../common/events';
 import { INodeLaunchConfiguration } from '../../configuration';
-import { ProtocolError, createUserError } from '../../dap/errors';
+import { ProtocolError } from '../../dap/errors';
 import { findInPath, findExecutable } from '../../common/pathUtils';
-import { EnvironmentVars } from '../../common/environmentVars';
 import { ILaunchContext } from '../targets';
+import { IProgram } from './program';
+import { EnvironmentVars } from '../../common/environmentVars';
 
 const localize = nls.loadMessageBundle();
+/**
+ * Interface that handles booting a program to debug.
+ */
+export interface IProgramLauncher {
+  /**
+   * Returns whether this launcher is appropriate for the given set of options.
+   */
+  canLaunch(args: INodeLaunchConfiguration): boolean;
+
+  /**
+   * Executs the program.
+   */
+  launchProgram(args: INodeLaunchConfiguration, context: ILaunchContext): Promise<IProgram>;
+}
 
 /**
  * Launcher that boots a subprocess.
  */
 export abstract class ProcessLauncher implements IProgramLauncher {
-  protected _onProgramStoppedEmitter = new EventEmitter<void>();
-  public onProgramStopped = this._onProgramStoppedEmitter.event;
+  public canLaunch(_args: INodeLaunchConfiguration): boolean {
+    return true;
+  }
 
-  public async launchProgram(args: INodeLaunchConfiguration, context: ILaunchContext): Promise<void> {
-    const env = this.resolveEnvironment(args);
+  public abstract launchProgram(
+    args: INodeLaunchConfiguration,
+    context: ILaunchContext,
+  ): Promise<IProgram>;
+
+  protected getRuntime(args: INodeLaunchConfiguration) {
     let requestedRuntime = args.runtimeExecutable || 'node';
+    const env = EnvironmentVars.merge(process.env, args.env).value;
     const resolvedRuntime = findExecutable(
       path.isAbsolute(requestedRuntime) ? requestedRuntime : findInPath(requestedRuntime, env),
       env,
     );
+
     if (!resolvedRuntime) {
       throw new ProtocolError({
         id: 2001,
@@ -41,64 +60,6 @@ export abstract class ProcessLauncher implements IProgramLauncher {
       });
     }
 
-    await this.launch({ ...args, env, runtimeExecutable: resolvedRuntime }, context);
+    return resolvedRuntime;
   }
-
-  private resolveEnvironment(args: INodeLaunchConfiguration) {
-    let env = new EnvironmentVars(process.env);
-
-    // read environment variables from any specified file
-    if (args.envFile) {
-      try {
-        env = env.merge(readEnvFile(args.envFile));
-      } catch (e) {
-        throw new ProtocolError(
-          createUserError(
-            localize('VSND2029', "Can't load environment variables from file ({0}).", e.message),
-          ),
-        );
-      }
-    }
-
-    return env.merge(args.env).value;
-  }
-
-  public abstract stopProgram(): void;
-
-  public dispose() {
-    this.stopProgram();
-  }
-
-  protected abstract launch(args: INodeLaunchConfiguration, context: ILaunchContext): Promise<number>;
-}
-
-function readEnvFile(file: string): { [key: string]: string } {
-  if (!fs.existsSync(file)) {
-    return {};
-  }
-
-  const buffer = stripBOM(fs.readFileSync(file, 'utf8'));
-  const env = {};
-  for (const line of buffer.split('\n')) {
-    const r = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
-    if (!r) {
-      continue;
-    }
-
-    let [, key, value = ''] = r;
-    // .env variables never overwrite existing variables (see #21169)
-    if (value.length > 0 && value.charAt(0) === '"' && value.charAt(value.length - 1) === '"') {
-      value = value.replace(/\\n/gm, '\n');
-    }
-    env[key] = value.replace(/(^['"]|['"]$)/g, '');
-  }
-
-  return env;
-}
-
-function stripBOM(s: string): string {
-  if (s && s[0] === '\uFEFF') {
-    s = s.substr(1);
-  }
-  return s;
 }

--- a/src/targets/node/program.ts
+++ b/src/targets/node/program.ts
@@ -1,0 +1,118 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { IProcessTelemetry } from './nodeLauncher';
+import { ChildProcess } from 'child_process';
+import { killTree } from './killTree';
+import Dap from '../../dap/api';
+
+export interface IProgram {
+  readonly stopped: Promise<void>;
+
+  /**
+   * Callback given to the program after telemetry is queried.
+   */
+  gotTelemetery(telemetry: IProcessTelemetry): void;
+
+  /**
+   * Forcefully stops the program.
+   */
+  stop(): Promise<void>;
+}
+
+/**
+ * Program created from a subprocess.
+ */
+export class SubprocessProgram implements IProgram {
+  public readonly stopped: Promise<void>;
+
+  constructor(private child: ChildProcess) {
+    this.stopped = new Promise((resolve, reject) => {
+      child.once('exit', resolve);
+      child.once('error', reject);
+    });
+  }
+
+  public gotTelemetery() {
+    // no-op
+  }
+
+  public stop(): Promise<void> {
+    killTree(this.child.pid);
+    return this.stopped;
+  }
+}
+
+/**
+ * Program created from a subprocess.
+ */
+export class TerminalProcess implements IProgram {
+  /**
+   * How often to check and see if the process exited.
+   */
+  private static readonly terminationPollInterval = 1000;
+
+  private didStop = false;
+  private onStopped!: () => void;
+  public readonly stopped = new Promise<void>(
+    resolve =>
+      (this.onStopped = () => {
+        this.didStop = true;
+        resolve();
+      }),
+  );
+  private loop?: { timer: NodeJS.Timer; processId: number };
+
+  constructor(private readonly terminalResult: Dap.RunInTerminalResult) {
+    if (terminalResult.processId) {
+      this.startPollLoop(terminalResult.processId);
+    }
+  }
+
+  public gotTelemetery({ processId }: IProcessTelemetry) {
+    this.startPollLoop(processId);
+  }
+
+  public stop(): Promise<void> {
+    this.onStopped();
+
+    if (!this.loop) {
+      if (this.terminalResult.shellProcessId) {
+        killTree(this.terminalResult.shellProcessId);
+      }
+
+      return Promise.resolve();
+    }
+
+    killTree(this.loop.processId);
+    clearInterval(this.loop.timer);
+    return this.stopped;
+  }
+
+  private startPollLoop(processId: number) {
+    if (this.loop) {
+      return;
+    }
+
+    if (this.didStop) {
+      killTree(processId);
+      return; // to avoid any races
+    }
+
+    const loop = {
+      processId,
+      timer: setInterval(() => {
+        try {
+          // kill with signal=0 just test for whether the proc is alive. It throws if not.
+          process.kill(processId, 0);
+        } catch {
+          clearInterval(loop.timer);
+          this.onStopped();
+        }
+      }, TerminalProcess.terminationPollInterval),
+    };
+
+    this.loop = loop;
+  }
+}

--- a/src/targets/node/restartPolicy.ts
+++ b/src/targets/node/restartPolicy.ts
@@ -1,0 +1,52 @@
+import { INodeLaunchConfiguration } from '../../configuration';
+import { IStopMetadata } from '../targets';
+
+/**
+ * Creates restart policies from the configuration.
+ */
+export class RestartPolicyFactory {
+  public create(config: INodeLaunchConfiguration): IRestartPolicy {
+    if (!config.restart) {
+      return new NeverRestartPolicy();
+    }
+
+    return new StaticRestartPolicy(1000);
+  }
+}
+
+/**
+ * Configures how the program should be restarted if it crashes.
+ */
+export interface IRestartPolicy {
+  readonly delay: number;
+
+  /**
+   * Returns the delay before the server should be restarted, or undefined
+   * if no restart should occur.
+   */
+  next(result: IStopMetadata): IRestartPolicy | undefined;
+}
+
+/**
+ * Restart policy with a static delay.
+ * @see https://github.com/microsoft/vscode-pwa/issues/26
+ */
+class StaticRestartPolicy implements IRestartPolicy {
+  constructor(public readonly delay: number) {}
+
+  public next(result: IStopMetadata) {
+    if (result.killed || result.code === 0) {
+      return;
+    }
+
+    return this;
+  }
+}
+
+class NeverRestartPolicy implements IRestartPolicy {
+  public readonly delay = -1;
+
+  public next() {
+    return undefined;
+  }
+}

--- a/src/targets/node/subprocessProgramLauncher.ts
+++ b/src/targets/node/subprocessProgramLauncher.ts
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import { INodeLaunchConfiguration } from '../../configuration';
+import { ProcessLauncher } from './processLauncher';
+import { ILaunchContext } from '../targets';
+import { spawn } from 'child_process';
+import { SubprocessProgram } from './program';
+import { EnvironmentVars } from '../../common/environmentVars';
+
+/**
+ * Launcher that boots a subprocess.
+ */
+export class SubprocessProgramLauncher extends ProcessLauncher {
+  public canLaunch(args: INodeLaunchConfiguration) {
+    return args.console === 'internalConsole';
+  }
+
+  public async launchProgram(config: INodeLaunchConfiguration, context: ILaunchContext) {
+    const { executable, args, shell } = formatArguments(this.getRuntime(config), [
+      ...config.runtimeArgs,
+      config.program,
+      ...config.args,
+    ]);
+
+    // Send an appoximation of the command we're running to
+    // the terminal, for cosmetic purposes.
+    context.dap.output({
+      category: 'console',
+      output: [executable, ...args].join(' '),
+    });
+
+    // todo: WSL support
+
+    const child = spawn(executable, args, {
+      shell,
+      cwd: config.cwd,
+      env: EnvironmentVars.merge(process.env, config.env).defined(),
+    });
+
+    child.stdout.addListener('data', data => {
+      context.dap.output({
+        category: 'stdout',
+        output: data.toString(),
+      });
+    });
+
+    child.stderr.addListener('data', data => {
+      context.dap.output({
+        category: 'stderr',
+        output: data.toString(),
+      });
+    });
+
+    child.on('error', err => {
+      context.dap.output({
+        category: 'stderr',
+        output: err.stack || err.message,
+      });
+    });
+
+    child.on('exit', code =>
+      context.dap.output({
+        category: 'stderr',
+        output: `Process exited with code ${code}`,
+      }),
+    );
+
+    return new SubprocessProgram(child);
+  }
+}
+
+// Fix for: https://github.com/microsoft/vscode/issues/45832,
+// which still seems to be a thing according to the issue tracker.
+// From: https://github.com/microsoft/vscode-node-debug/blob/47747454bc6e8c9e48d8091eddbb7ffb54a19bbe/src/node/nodeDebug.ts#L1120
+const formatArguments = (executable: string, args: ReadonlyArray<string>) => {
+  if (process.platform !== 'win32') {
+    return { executable, args, shell: false };
+  }
+
+  let foundArgWithSpace = false;
+
+  // check whether there is one arg with a space
+  const output: string[] = [];
+  for (const a of args) {
+    if (a.includes(' ')) {
+      output.push(`"${a}"`);
+      foundArgWithSpace = true;
+    } else {
+      output.push(a);
+    }
+  }
+
+  if (foundArgWithSpace) {
+    return { executable, args: output, shell: true };
+  }
+
+  return { executable, args, shell: false };
+};

--- a/src/targets/node/terminalProgramLauncher.ts
+++ b/src/targets/node/terminalProgramLauncher.ts
@@ -4,140 +4,51 @@
 import { INodeLaunchConfiguration } from '../../configuration';
 import { ProcessLauncher } from './processLauncher';
 import { ILaunchContext } from '../targets';
-import { spawn, ChildProcess, spawnSync, execSync } from 'child_process';
+import * as nls from 'vscode-nls';
+import Dap from '../../dap/api';
+import { ProtocolError, cannotLaunchInTerminal } from '../../dap/errors';
+import { TerminalProcess } from './program';
 import { removeNulls } from '../../common/objUtils';
-import { join } from 'path';
+
+const localize = nls.loadMessageBundle();
 
 /**
  * Launcher that boots a subprocess.
  */
 export class TerminalProgramLauncher extends ProcessLauncher {
-  private process?: ChildProcess;
-
-  public stopProgram(): void {
-    if (this.process) {
-      killTree(this.process.pid);
-      this.process = undefined;
-    }
+  public canLaunch(args: INodeLaunchConfiguration) {
+    args.internalConsoleOptions;
+    return args.console !== 'internalConsole';
   }
 
-  protected async launch(config: INodeLaunchConfiguration, context: ILaunchContext) {
-    const { executable, args, shell } = formatArguments(config.runtimeExecutable || 'node', [
-      ...config.runtimeArgs,
-      config.program,
-      ...config.args,
-    ]);
-
-    // Send an appoximation of the command we're running to
-    // the terminal, for cosmetic purposes.
-    context.dap.output({
-      category: 'console',
-      output: [executable, ...args].join(' '),
-    });
-
-    // todo: WSL support
-
-    const process = (this.process = spawn(executable, args, {
-      shell,
+  public async launchProgram(config: INodeLaunchConfiguration, context: ILaunchContext) {
+    const params: Dap.RunInTerminalParams = {
+      kind: config.console === 'integratedTerminal' ? 'integrated' : 'external',
+      title: localize('node.console.title', 'Node Debug Console'),
       cwd: config.cwd,
+      args: [
+        this.getRuntime(config),
+        ...config.runtimeArgs,
+        config.program,
+        ...config.args,
+      ],
       env: removeNulls(config.env),
-    }));
+    };
 
-    process.stdout.addListener('data', data => {
-      context.dap.output({
-        category: 'stdout',
-        output: data,
-      });
-    });
-
-    process.stderr.addListener('data', data => {
-      context.dap.output({
-        category: 'stderr',
-        output: data,
-      });
-    });
-
-    process.on('error', err => {
-      context.dap.output({
-        category: 'stderr',
-        output: err.stack || err.message,
-      });
-
-      this.emitProgramStop(process, null, context);
-    });
-
-    process.on('exit', code => this.emitProgramStop(process, code, context));
-
-    return process.pid;
-  }
-
-  private emitProgramStop(process: ChildProcess, code: number | null, context: ILaunchContext) {
-    if (code !== null && code !== 0) {
-      context.dap.output({
-        category: 'stderr',
-        output:
-          process === this.process
-            ? `Process exited with code ${code}`
-            : `Process exited with code ${code} after being killed`,
-      });
-    }
-
-    if (this.process === process) {
-      this.process = undefined;
-    }
-
-    this._onProgramStoppedEmitter.fire();
-  }
-}
-
-// Fix for: https://github.com/microsoft/vscode/issues/45832,
-// which still seems to be a thing according to the issue tracker.
-// From: https://github.com/microsoft/vscode-node-debug/blob/47747454bc6e8c9e48d8091eddbb7ffb54a19bbe/src/node/nodeDebug.ts#L1120
-const formatArguments = (executable: string, args: ReadonlyArray<string>) => {
-  if (process.platform !== 'win32') {
-    return { executable, args, shell: false };
-  }
-
-  let foundArgWithSpace = false;
-
-  // check whether there is one arg with a space
-  const output: string[] = [];
-  for (const a of args) {
-    if (a.includes(' ')) {
-      output.push(`"${a}"`);
-      foundArgWithSpace = true;
-    } else {
-      output.push(a);
-    }
-  }
-
-  if (foundArgWithSpace) {
-    return { executable, args: output, shell: true };
-  }
-
-  return { executable, args, shell: false };
-};
-
-function killTree(processId: number): void {
-  if (process.platform === 'win32') {
-    const windir = process.env['WINDIR'] || 'C:\\Windows';
-    const TASK_KILL = join(windir, 'System32', 'taskkill.exe');
-
-    // when killing a process in Windows its child processes are *not* killed but become root processes.
-    // Therefore we use TASKKILL.EXE
+    let result: Dap.RunInTerminalResult;
     try {
-      execSync(`${TASK_KILL} /F /T /PID ${processId}`);
+      result = await this.sendLaunchRequest(params, context);
     } catch (err) {
-      // ignored
+      throw new ProtocolError(cannotLaunchInTerminal(err.message));
     }
-  } else {
-    // on linux and OS X we kill all direct and indirect child processes as well
-    try {
-      const cmd = join(__dirname, './terminateProcess.sh');
-      spawnSync(cmd, [processId.toString()]);
-    } catch (err) {
-      console.log(err);
-      // ignored
-    }
+
+    return new TerminalProcess(result);
+  }
+
+  /**
+   * Sends the launch request -- stubbed out in tests.
+   */
+  public sendLaunchRequest(params: Dap.RunInTerminalParams, context: ILaunchContext) {
+    return context.dap.runInTerminalRequest(params);
   }
 }

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -50,12 +50,30 @@ export interface LaunchResult {
   blockSessionTermination?: boolean;
 }
 
+/**
+ * Data emitted in the 'stopped' promise.
+ */
+export interface IStopMetadata {
+  /**
+   * Numeric close code, non-zero exits are treated as errors.
+   */
+  code: number;
+  /**
+   * True if the launcher was intentionally closed by a user.
+   */
+  killed: boolean;
+  /**
+   * Any error that occurred.
+   */
+  error?: Error;
+}
+
 export interface Launcher extends Disposable {
   launch(params: AnyLaunchConfiguration, context: ILaunchContext): Promise<LaunchResult>;
   terminate(): Promise<void>;
   disconnect(): Promise<void>;
   restart(): Promise<void>;
   onTargetListChanged: Event<void>;
-  onTerminated: Event<void>;
+  onTerminated: Event<IStopMetadata>;
   targetList(): Target[];
 }

--- a/src/test/test.ts
+++ b/src/test/test.ts
@@ -20,6 +20,7 @@ import { EventEmitter } from '../common/events';
 import { IChromeLaunchConfiguration, chromeLaunchConfigDefaults, nodeLaunchConfigDefaults, INodeLaunchConfiguration } from '../configuration';
 import { tmpdir } from 'os';
 import { NodeLauncher } from '../targets/node/nodeLauncher';
+import { SubprocessProgramLauncher } from '../targets/node/subprocessProgramLauncher';
 import { TerminalProgramLauncher } from '../targets/node/terminalProgramLauncher';
 
 export const kStabilizeNames = ['id', 'threadId', 'sourceReference', 'variablesReference'];
@@ -303,7 +304,7 @@ export class TestRoot {
 
     const storagePath = path.join(__dirname, '..', '..');
     this._browserLauncher = new BrowserLauncher(storagePath);
-    this._nodeLauncher = new NodeLauncher(new TerminalProgramLauncher());
+    this._nodeLauncher = new NodeLauncher([new SubprocessProgramLauncher(), new TerminalProgramLauncher()]);
     this.binder = new Binder(this, this._root.adapterConnection, [this._browserLauncher, this._nodeLauncher], '0');
 
     this.initialize = this._root._init();

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -27,7 +27,7 @@ function setupCoverage() {
   return nyc;
 }
 
-export async function run(root: string): Promise<void> {
+export async function run(): Promise<void> {
   const nyc = process.env.COVERAGE ? setupCoverage() : null;
 
   const runner = new Mocha({

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -32,7 +32,6 @@ export async function run(root: string): Promise<void> {
 
   const runner = new Mocha({
     timeout: 2000000,
-    grep: 'browser launch runtime',
     ...JSON.parse(process.env.PWA_TEST_OPTIONS || '{}'),
   });
 

--- a/src/ui/sessionManager.ts
+++ b/src/ui/sessionManager.ts
@@ -11,9 +11,10 @@ import { BrowserAttacher } from '../targets/browser/browserAttacher';
 import { Target } from '../targets/targets';
 import { Disposable } from '../common/events';
 import { checkVersion } from './version';
-import { TerminalProgramLauncher } from '../targets/node/terminalProgramLauncher';
+import { SubprocessProgramLauncher } from '../targets/node/subprocessProgramLauncher';
 import { DebugAdapter } from '../adapter/debugAdapter';
 import { Contributions } from '../common/contributionUtils';
+import { TerminalProgramLauncher } from '../targets/node/terminalProgramLauncher';
 
 export class Session implements Disposable {
   public readonly debugSession: vscode.DebugSession;
@@ -39,7 +40,7 @@ export class Session implements Disposable {
 
   createBinder(context: vscode.ExtensionContext, delegate: BinderDelegate) {
     const launchers = [
-      new NodeLauncher(new TerminalProgramLauncher()),
+      new NodeLauncher([new SubprocessProgramLauncher(), new TerminalProgramLauncher()]),
       new BrowserLauncher(context.storagePath || context.extensionPath),
       new BrowserAttacher(),
     ];


### PR DESCRIPTION
This implements the `console` option, allowing programs to be opened in the
integration debug console, terminal, or external terminal. I also took the
opportunity to look at lifecycles a little more: I've adjusted the program
launchers (now a subprocess launcher and a terminal launcher) to be stateless
and create `IProgram` instances that carry the session state.

This also involves implementing the callback from the subprocess to the parent
one (containing the process ID and runtime metadata). In the debug2
implementation, we evaluate and return an expression via CDP. In here I've
implemented it as a file callback, where the process writes JSON that the
debug adapter reads. I think this might be a little more simple and reliable--
there's a pretty decent chunk of logic in debug2 about trying and retrying to
evaluate the expression over CDP, and it depends on hitting a breakpoint.
Here we write it out in the bootloader and poll the filesystem for it. It
seems to work well, interested to hear any thoughts (cc @roblourens )

CDP API generator was previously missing method calls, and only generated
event calls and listeners in the typings. It may make sense to move back to
the official package in the future, but for now I've just patched the
generator.

Fixes #38 