### PR TITLE
feat: initial implementation of node attach

### DIFF
--- a/demos/node/child.js
+++ b/demos/node/child.js
@@ -1,0 +1,4 @@
+setTimeout(
+  () => console.log(`Hello from child ${process.argv[2]}! Options:`, process.env.NODE_OPTIONS),
+  2000,
+);

--- a/demos/node/parent.js
+++ b/demos/node/parent.js
@@ -1,0 +1,8 @@
+const { spawn } = require('child_process');
+
+let counter = 0;
+setInterval(() => {
+  const id = counter++;
+  console.log('Spawning child', id);
+  spawn('node', ['child', id], { cwd: __dirname, stdio: 'inherit' });
+}, 5000);

--- a/package-lock.json
+++ b/package-lock.json
@@ -4997,7 +4997,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5206,12 +5207,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5230,6 +5233,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5409,7 +5413,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5465,6 +5470,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5508,12 +5514,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -911,7 +911,7 @@
                   "stopOnEntry": {
                     "type": "boolean",
                     "description": "%node.stopOnEntry.description%",
-                    "default": true
+                    "default": false
                   },
                   "console": {
                     "type": "string",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
   "activationEvents": [
     "onDebugInitialConfigurations",
     "onDebugResolve:NAMESPACE(node)",
-    "onCommand:extension.pickNodeProcess",
+    "onCommand:extension.NAMESPACE(node-debug).pickNodeProcess",
     "onCommand:extension.NAMESPACE(node-debug).prettyPrint",
     "onCommand:extension.NAMESPACE(node-debug).pickLoadedScript",
     "onCommand:extension.NAMESPACE(node-debug).toggleSkippingFile",
@@ -175,6 +175,11 @@
           "light": "resources/light/remove-all.svg",
           "dark": "resources/dark/remove-all.svg"
         }
+      },
+      {
+        "command": "extension.NAMESPACE(node-debug).attachNodeProcess",
+        "title": "%attach.node.process%",
+        "category": "Debug"
       }
     ],
     "menus": {
@@ -241,6 +246,9 @@
       {
         "type": "NAMESPACE(node)",
         "label": "%node.label%",
+        "variables": {
+          "PickProcess": "onCommand:extension.NAMESPACE(node-debug).pickNodeProcess"
+        },
         "configurationSnippets": [
           {
             "label": "%node.snippet.launch.label%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -37,6 +37,8 @@
   "node.address.description": "TCP/IP address of process to be debugged. Default is 'localhost'.",
   "node.attach.config.name": "Attach",
   "node.attach.processId.description": "ID of process to attach to.",
+  "node.attach.attachSpawnedProcesses.description": "Whether to set environment variables in the attached process to track spawned children.",
+  "node.attach.attachExistingChildren.description": "Whether to attempt to attach to already-spawned child processes.",
   "node.console.title": "Node Debug Console",
   "node.disableOptimisticBPs.description": "Don't set breakpoints in any file until a sourcemap has been loaded for that file.",
   "node.label": "Node.js",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,12 +1,11 @@
 {
-  "attach.node.process": "Attach to Node Process",
+  "attach.node.process": "Attach to Node Process (PWA)",
   "extension.description": "Node.js debugging support (versions < 8.0)",
   "start.with.stop.on.entry": "Start Debugging and Stop on Entry",
   "toggle.skipping.this.file": "Toggle Skipping this File",
   "add.browser.breakpoint": "Add Browser Breakpoint",
   "remove.browser.breakpoint": "Remove Browser Breakpoint",
   "remove.browser.breakpoint.all": "Remove All Browser Breakpoints",
-
 
 	"chrome.address.description": "TCP/IP address of debug port",
 	"chrome.baseUrl.description": "Base URL to resolve paths baseUrl. baseURL is trimmed when mapping URLs to the files on disk. Defaults to the launch URL domain.",

--- a/scripts/generate-cdp-api.js
+++ b/scripts/generate-cdp-api.js
@@ -147,9 +147,21 @@ async function generate() {
     result.push(`  }`);
   }
 
+  function appendPauseResume() {
+    result.push(`    /**`);
+    result.push(`     * Pauses events being sent through the aPI.`);
+    result.push(`     */`);
+    result.push(`    pause(): void;`);
+    result.push(`    /**`);
+    result.push(`     * Resumes previously-paused events`);
+    result.push(`     */`);
+    result.push(`    resume(): void;`);
+  }
+
   interfaceSeparator();
   appendText('Protocol API.', '  ');
   result.push(`  export interface Api {`);
+  appendPauseResume();
   domains.forEach(d => {
     result.push(`    ${d.domain}: ${d.domain}Api;`)
   });

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -49,12 +49,18 @@ export class ExecutionContext {
 export type Script = { url: string, scriptId: string, hash: string, source: Source };
 
 export interface ThreadDelegate {
+  /**
+   * Handler triggered on a breakpoint. If this returns true, the UI will be
+   * continued and no breakpoint will be shown to the user.
+   */
+  onPaused(details: Cdp.Debugger.PausedEvent): Promise<boolean>;
   supportsCustomBreakpoints(): boolean;
   shouldCheckContentHash(): boolean;
   defaultScriptOffset(): InlineScriptOffset | undefined;
   scriptUrlToUrl(url: string): string;
   executionContextName(description: Cdp.Runtime.ExecutionContextDescription): string;
   blackboxPattern(): string | undefined;
+  initialize(): Promise<void>
 }
 
 export type ScriptWithSourceMapHandler = (script: Script, sources: Source[]) => Promise<void>;
@@ -397,6 +403,10 @@ export class Thread implements VariableStoreDelegate {
         return;
       }
 
+      if (await this._delegate.onPaused(event)) {
+        return;
+      }
+
       this._pausedDetails = this._createPausedDetails(event);
       this._pausedDetails[kPausedEventSymbol] = event;
       this._pausedVariables = new VariableStore(this._cdp, this);
@@ -404,10 +414,10 @@ export class Thread implements VariableStoreDelegate {
       this._onThreadPaused();
     });
     this._cdp.Debugger.on('resumed', () => this._onResumed());
-
     this._cdp.Debugger.on('scriptParsed', event => this._onScriptParsed(event));
 
     this._ensureDebuggerEnabledAndRefreshDebuggerId();
+    this._delegate.initialize();
     this._cdp.Debugger.setAsyncCallStackDepth({ maxDepth: 32 });
     const blackboxPattern = this._delegate.blackboxPattern();
     if (blackboxPattern) {

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -172,7 +172,7 @@ export class Binder implements Disposable {
       });
     }
 
-    cdp.resume();
+    await target.afterBind();
   }
 
   async detach(target: Target) {

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -171,6 +171,8 @@ export class Binder implements Disposable {
         return {};
       });
     }
+
+    cdp.resume();
   }
 
   async detach(target: Target) {

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -59,15 +59,12 @@ export class Binder implements Disposable {
       dap.on('configurationDone', async () => ({}));
       dap.on('threads', async () => ({ threads: [] }));
       dap.on('loadedSources', async () => ({ sources: [] }));
-      dap.on('launch', async rawParams => {
-        const params = rawParams as AnyLaunchConfiguration;
-        if (params.rootPath)
-          params.rootPath = urlUtils.platformPathToPreferredCase(params.rootPath);
-        this._launchParams = params;
-        let results = await Promise.all(launchers.map(l => this._launch(l, params)));
-        results = results.filter(result => !!result);
-        if (results.length)
-          return errors.createUserError(results.join('\n'));
+      dap.on('attach', async params => {
+        await this._boot(params as AnyLaunchConfiguration);
+        return {};
+      });
+      dap.on('launch', async params => {
+        await this._boot(params as AnyLaunchConfiguration);
         return {};
       });
       dap.on('terminate', async () => {
@@ -83,6 +80,17 @@ export class Binder implements Disposable {
         return {};
       });
     });
+  }
+
+  private async _boot(params: AnyLaunchConfiguration) {
+    if (params.rootPath)
+      params.rootPath = urlUtils.platformPathToPreferredCase(params.rootPath);
+    this._launchParams = params;
+    let results = await Promise.all([...this._launchers].map(l => this._launch(l, params)));
+    results = results.filter(result => !!result);
+    if (results.length)
+      return errors.createUserError(results.join('\n'));
+    return {};
   }
 
   async _restart() {

--- a/src/cdp/connection.ts
+++ b/src/cdp/connection.ts
@@ -74,7 +74,6 @@ export default class Connection {
     if (sessionId)
       message.sessionId = sessionId;
     const messageString = JSON.stringify(message);
-    // console.log(`SEND ► ${messageString}`);
     if (this._logPath)
       require('fs').appendFileSync(this._logPath, `SEND ► [${this._logPrefix}] ${messageString}\n`);
     this._transport.send(messageString);
@@ -271,7 +270,6 @@ class CDPSession {
         callback.resolve(object.result!);
       }
     } else {
-      // console.log(`◀ RECV EV ${JSON.stringify(object)}`);
       const listeners = this._listeners.get(object.method!);
       for (const listener of listeners || [])
         listener(object.params);

--- a/src/common/contributionUtils.ts
+++ b/src/common/contributionUtils.ts
@@ -6,6 +6,8 @@ export const enum Contributions {
   PrettyPrintCommand = 'extension.NAMESPACE(node-debug).prettyPrint',
   PickLoadedScriptCommand = 'extension.NAMESPACE(node-debug).pickLoadedScript',
   ToggleSkippingCommand = 'extension.NAMESPACE(node-debug).toggleSkippingFile',
+  PickProcessCommand = 'extension.NAMESPACE(node-debug).pickNodeProcess',
+  AttachProcessCommand = 'extension.NAMESPACE(node-debug).attachNodeProcess',
 
   AddCustomBreakpointsCommand = 'extension.NAMESPACE(chrome-debug).addCustomBreakpoints',
   RemoveCustomBreakpointCommand = 'extension.NAMESPACE(chrome-debug).removeCustomBreakpoint',

--- a/src/common/objUtils.ts
+++ b/src/common/objUtils.ts
@@ -12,7 +12,7 @@ export const removeUndefined = <V>(obj: { [key: string]: V | undefined }) =>
  * Filters the object by value.
  */
 export function filterValues<V, F extends V>(
-  obj: { [key: string]: V },
+  obj: Readonly<{ [key: string]: V }>,
   predicate: (value: V, key: string) => value is F,
 ): { [key: string]: F } {
   const next: { [key: string]: F } = {};
@@ -21,6 +21,22 @@ export function filterValues<V, F extends V>(
     if (predicate(value, key)) {
       next[key] = value;
     }
+  }
+
+  return next;
+}
+
+/**
+ * Maps the object values.
+ */
+export function mapValues<T, R>(
+  obj: Readonly<{ [key: string]: T }>,
+  generator: (value: T, key: string) => R,
+): { [key: string]: R } {
+  const next: { [key: string]: R } = {};
+  for (const key of Object.keys(obj)) {
+    const value = obj[key];
+    next[key] = generator(value, key);
   }
 
   return next;

--- a/src/common/pathUtils.ts
+++ b/src/common/pathUtils.ts
@@ -12,7 +12,7 @@ import { removeNulls } from './objUtils';
  */
 export function findInPath(
   program: string,
-  env: { [key: string]: string | null },
+  env: { [key: string]: string | null | undefined },
 ): string | undefined {
   let locator: string;
   if (process.platform === 'win32') {

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -181,3 +181,23 @@ export function platformPathToPreferredCase(p: string | undefined): string | und
   if (p && process.platform === 'win32' && p[1] === ':') return p[0].toUpperCase() + p.substring(1);
   return p;
 }
+
+const loopbacks: ReadonlySet<string> = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '0:0:0:0:0:0:0:1',
+]);
+
+/**
+ * Returns whether the given URL is a loopback address.
+ */
+
+export const isLoopback = (address: string) => {
+  try {
+    const url = new URL(address);
+    return loopbacks.has(url.hostname);
+  } catch {
+    return loopbacks.has(address);
+  }
+};

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -249,11 +249,6 @@ export interface INodeAttachConfiguration extends INodeBaseConfiguration {
    * ID of process to attach to.
    */
   processId?: string;
-
-  /**
-   * Process ID after resolution.
-   */
-  _resolvedProcessId?: number;
 }
 
 export interface IChromeLaunchConfiguration extends IChromeBaseConfiguration {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -146,6 +146,11 @@ export interface INodeBaseConfiguration extends IBaseConfiguration {
    * loaded for that file.
    */
   disableOptimisticBPs: boolean;
+
+  /**
+   * Attach debugger to new child processes automatically.
+   */
+  autoAttachChildProcesses: boolean;
 }
 
 /**
@@ -199,12 +204,7 @@ export interface INodeLaunchConfiguration extends INodeBaseConfiguration {
   /**
    * Absolute path to a file containing environment variable definitions.
    */
-  envFile: string;
-
-  /**
-   * Attach debugger to new child processes automatically.
-   */
-  autoAttachChildProcesses: boolean;
+  envFile: string | null;
 }
 
 interface IChromeBaseConfiguration extends IBaseConfiguration {
@@ -248,7 +248,12 @@ export interface INodeAttachConfiguration extends INodeBaseConfiguration {
   /**
    * ID of process to attach to.
    */
-  processId: string;
+  processId?: string;
+
+  /**
+   * Process ID after resolution.
+   */
+  _resolvedProcessId?: number;
 }
 
 export interface IChromeLaunchConfiguration extends IChromeBaseConfiguration {
@@ -317,7 +322,9 @@ export type AnyNodeConfiguration = INodeAttachConfiguration | INodeLaunchConfigu
 export type AnyChromeConfiguration = IChromeAttachConfiguration | IChromeLaunchConfiguration;
 export type AnyLaunchConfiguration = AnyChromeConfiguration | AnyNodeConfiguration;
 
-export type ResolvingNodeConfiguration = IMandatedConfiguration & Partial<AnyNodeConfiguration>;
+export type ResolvingNodeAttachConfiguration = IMandatedConfiguration & Partial<INodeAttachConfiguration>;
+export type ResolvingNodeLaunchConfiguration = IMandatedConfiguration & Partial<INodeLaunchConfiguration>;
+export type ResolvingNodeConfiguration = ResolvingNodeAttachConfiguration | ResolvingNodeLaunchConfiguration;
 export type ResolvingChromeConfiguration = IMandatedConfiguration & Partial<AnyChromeConfiguration>;
 
 const baseDefaults: IBaseConfiguration = {
@@ -338,8 +345,8 @@ const baseDefaults: IBaseConfiguration = {
   sourceMaps: true,
   sourceMapPathOverrides: {
     'webpack:///*': '*',
-    'webpack:///./~/*': '${workspaceRoot}/node_modules/*',
-    'meteor://💻app/*': '${workspaceRoot}/*',
+    'webpack:///./~/*': '${workspaceFolder}/node_modules/*',
+    'meteor://💻app/*': '${workspaceFolder}/*',
   },
 };
 
@@ -354,6 +361,7 @@ const nodeBaseDefaults: INodeBaseConfiguration = {
   remoteRoot: null,
   trace: true,
   disableOptimisticBPs: true,
+  autoAttachChildProcesses: true,
 };
 
 export const nodeLaunchConfigDefaults: INodeLaunchConfiguration = {
@@ -363,13 +371,11 @@ export const nodeLaunchConfigDefaults: INodeLaunchConfiguration = {
   stopOnEntry: true,
   console: 'internalConsole',
   args: [],
-  cwd: '${workspaceFolder}',
   runtimeExecutable: 'node',
   runtimeVersion: 'default',
   runtimeArgs: [],
   env: {},
-  envFile: '${workspaceFolder}/.env',
-  autoAttachChildProcesses: true,
+  envFile: null,
 };
 
 export const chromeAttachConfigDefaults: IChromeAttachConfiguration = {

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -249,6 +249,17 @@ export interface INodeAttachConfiguration extends INodeBaseConfiguration {
    * ID of process to attach to.
    */
   processId?: string;
+
+  /**
+   * Whether to set environment variables in the attached process to track
+   * spawned children.
+   */
+  attachSpawnedProcesses: boolean;
+
+  /**
+   * Whether to attempt to attach to already-spawned child processes.
+   */
+  attachExistingChildren: boolean;
 }
 
 export interface IChromeLaunchConfiguration extends IChromeBaseConfiguration {
@@ -363,7 +374,7 @@ export const nodeLaunchConfigDefaults: INodeLaunchConfiguration = {
   ...nodeBaseDefaults,
   request: 'launch',
   program: '',
-  stopOnEntry: true,
+  stopOnEntry: false,
   console: 'internalConsole',
   args: [],
   runtimeExecutable: 'node',
@@ -401,6 +412,8 @@ export const chromeLaunchConfigDefaults: IChromeLaunchConfiguration = {
 
 export const nodeAttachConfigDefaults: INodeAttachConfiguration = {
   ...nodeBaseDefaults,
+  attachSpawnedProcesses: true,
+  attachExistingChildren: true,
   request: 'attach',
   processId: '',
 };

--- a/src/debugServer.ts
+++ b/src/debugServer.ts
@@ -17,6 +17,7 @@ import { generateBreakpointIds } from './adapter/breakpoints';
 import { SubprocessProgramLauncher } from './targets/node/subprocessProgramLauncher';
 import { TerminalProgramLauncher } from './targets/node/terminalProgramLauncher';
 import { IDisposable } from './common/disposable';
+import { NodeAttacher } from './targets/node/nodeAttacher';
 
 const storagePath = fs.mkdtempSync(path.join(os.tmpdir(), 'pwa-debugger-'));
 
@@ -82,6 +83,7 @@ export function startDebugServer(port: number): Promise<IDisposable> {
   return new Promise((resolve, reject) => {
     const server = net.createServer(async socket => {
       const launchers = [
+        new NodeAttacher(),
         new NodeLauncher([new SubprocessProgramLauncher(), new TerminalProgramLauncher()]),
         new BrowserLauncher(storagePath),
         new BrowserAttacher(),

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,8 +11,14 @@ import { DebugSessionTracker } from './ui/debugSessionTracker';
 import { NodeDebugConfigurationProvider } from './nodeDebugConfigurationProvider';
 import { ChromeDebugConfigurationProvider } from './chromeDebugConfigurationProvider';
 import { Contributions } from './common/contributionUtils';
+import { pickProcess, attachProcess } from './ui/processPicker';
 
 export function activate(context: vscode.ExtensionContext) {
+  context.subscriptions.push(
+    vscode.commands.registerCommand(Contributions.PickProcessCommand, pickProcess),
+    vscode.commands.registerCommand(Contributions.AttachProcessCommand, attachProcess),
+  );
+
   const nodeConfigProvider = new NodeDebugConfigurationProvider();
   const chromeConfigProvider = new ChromeDebugConfigurationProvider(nodeConfigProvider);
 

--- a/src/flatSessionLauncher.ts
+++ b/src/flatSessionLauncher.ts
@@ -24,6 +24,7 @@ import { Disposable } from './common/events';
 import { SubprocessProgramLauncher } from './targets/node/subprocessProgramLauncher';
 import { Contributions } from './common/contributionUtils';
 import { TerminalProgramLauncher } from './targets/node/terminalProgramLauncher';
+import { NodeAttacher } from './targets/node/nodeAttacher';
 
 const storagePath = fs.mkdtempSync(path.join(os.tmpdir(), 'pwa-debugger-'));
 
@@ -49,6 +50,7 @@ function main(inputStream: NodeJS.ReadableStream, outputStream: NodeJS.WritableS
   const _childSessionsForTarget = new Map<Target, ChildSession>();
   const launchers = [
     new NodeLauncher([new SubprocessProgramLauncher(), new TerminalProgramLauncher()]),
+    new NodeAttacher(),
     new BrowserLauncher(storagePath),
     new BrowserAttacher(),
   ];

--- a/src/nodeDebugConfigurationProvider.ts
+++ b/src/nodeDebugConfigurationProvider.ts
@@ -78,9 +78,9 @@ export class NodeDebugConfigurationProvider implements vscode.DebugConfiguration
     if (config.request === 'launch') {
       // nvm support
       if (typeof config.runtimeVersion === 'string' && config.runtimeVersion !== 'default') {
-        config.env = new EnvironmentVars(config.env)
-          .addToPath(await this.nvmResolver.resolveNvmVersionPath(config.runtimeVersion))
-          .value;
+        config.env = new EnvironmentVars(config.env).addToPath(
+          await this.nvmResolver.resolveNvmVersionPath(config.runtimeVersion),
+        ).value;
       }
 
       // when using "integratedTerminal" ensure that debug console doesn't get activated; see https://github.com/Microsoft/vscode/issues/43164
@@ -91,8 +91,8 @@ export class NodeDebugConfigurationProvider implements vscode.DebugConfiguration
 
     // "attach to process via picker" support
     if (config.request === 'attach' && typeof config.processId === 'string') {
-			if (!(await resolveProcessId(config))) {
-				return undefined;	// abort launch
+      if (!(await resolveProcessId(config))) {
+        return undefined; // abort launch
       }
     }
 

--- a/src/nodeDebugConfigurationProvider.ts
+++ b/src/nodeDebugConfigurationProvider.ts
@@ -16,6 +16,7 @@ import {
 import { Contributions } from './common/contributionUtils';
 import { NvmResolver, INvmResolver } from './targets/node/nvmResolver';
 import { EnvironmentVars } from './common/environmentVars';
+import { resolveProcessId } from './ui/processPicker';
 
 const localize = nls.loadMessageBundle();
 
@@ -90,7 +91,9 @@ export class NodeDebugConfigurationProvider implements vscode.DebugConfiguration
 
     // "attach to process via picker" support
     if (config.request === 'attach' && typeof config.processId === 'string') {
-      throw new Error('Resolving process IDs not yet supported'); // todo
+			if (!(await resolveProcessId(config))) {
+				return undefined;	// abort launch
+      }
     }
 
     return config.request === 'attach'
@@ -99,7 +102,7 @@ export class NodeDebugConfigurationProvider implements vscode.DebugConfiguration
   }
 }
 
-function guessWorkingDirectory(
+export function guessWorkingDirectory(
   config: ResolvingNodeConfiguration,
   folder?: vscode.WorkspaceFolder,
 ): string {

--- a/src/targets/browser/browserTargets.ts
+++ b/src/targets/browser/browserTargets.ts
@@ -172,6 +172,8 @@ export class BrowserTarget implements Target {
 
   constructor(targetManager: BrowserTargetManager, targetInfo: Cdp.Target.TargetInfo, cdp: Cdp.Api, parentTarget: BrowserTarget | undefined, waitingForDebugger: boolean, ondispose: (t: BrowserTarget) => void) {
     this._cdp = cdp;
+    cdp.pause();
+
     this._manager = targetManager;
     this.parentTarget = parentTarget;
     this._waitingForDebugger = waitingForDebugger;
@@ -202,6 +204,11 @@ export class BrowserTarget implements Target {
 
   type(): string {
     return this._targetInfo.type;
+  }
+
+  afterBind() {
+    this._cdp.resume();
+    return Promise.resolve();
   }
 
   parent(): Target | undefined {

--- a/src/targets/browser/browserTargets.ts
+++ b/src/targets/browser/browserTargets.ts
@@ -211,6 +211,14 @@ export class BrowserTarget implements Target {
     return Promise.resolve();
   }
 
+  initialize() {
+    return Promise.resolve();
+  }
+
+  onPaused() {
+    return Promise.resolve(false);
+  }
+
   parent(): Target | undefined {
     if (this.parentTarget && !jsTypes.has(this.parentTarget.type()))
       return this.parentTarget.parentTarget;

--- a/src/targets/node/bootloader.ts
+++ b/src/targets/node/bootloader.ts
@@ -1,18 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { spawn } from 'child_process';
 import * as inspector from 'inspector';
-import * as path from 'path';
 import { writeFileSync } from 'fs';
-import { IProcessTelemetry } from './nodeLauncher';
+import { spawnWatchdog } from './watchdogSpawn';
+import { IProcessTelemetry } from './nodeLauncherBase';
 
-function debugLog(text: string) {
+function debugLog() {
   // require('fs').appendFileSync(require('path').join(require('os').homedir(), 'bootloader.txt'), `BOOTLOADER [${process.pid}] ${text}\n`);
 }
 
 (function() {
-  debugLog('args: ' + process.argv.join(' '));
+  debugLog();
   if (!process.env.NODE_INSPECTOR_IPC) return;
 
   // Electron support
@@ -56,11 +55,6 @@ function debugLog(text: string) {
 
   if (!waitForDebugger) return;
 
-  const kBootloader = path.sep + 'bootloader.js';
-  const kWatchdog = path.sep + 'watchdog.js';
-  if (!__filename.endsWith(kBootloader)) return;
-  const fileName = __filename.substring(0, __filename.length - kBootloader.length) + kWatchdog;
-
   const ppid = process.env.NODE_INSPECTOR_PPID || '';
   if (ppid === '' + process.pid) {
     // When we have two of our bootloaders in NODE_OPTIONS,
@@ -69,35 +63,27 @@ function debugLog(text: string) {
   }
   process.env.NODE_INSPECTOR_PPID = '' + process.pid;
 
-  debugLog('Opening inspector for scriptName: ' + scriptName);
+  debugLog();
   inspector.open(0, undefined, false);
 
   const info = {
+    ipcAddress: process.env.NODE_INSPECTOR_IPC,
     pid: String(process.pid),
     scriptName,
-    inspectorURL: inspector.url(),
+    inspectorURL: inspector.url()!,
     waitForDebugger,
     ppid,
   };
 
-  debugLog('Info: ' + JSON.stringify(info));
+  debugLog();
   const execPath = process.env.NODE_INSPECTOR_EXEC_PATH || process.execPath;
-  debugLog('Spawning: ' + execPath + ' ' + fileName);
+  debugLog();
 
-  const p = spawn(execPath, [fileName], {
-    env: {
-      NODE_INSPECTOR_INFO: JSON.stringify(info),
-      NODE_INSPECTOR_IPC: process.env.NODE_INSPECTOR_IPC,
-    },
-    stdio: 'ignore',
-    detached: true,
-  });
-  p.unref();
-  process.on('exit', () => p.kill());
+  spawnWatchdog(execPath, info);
 
   if (waitForDebugger) {
-    debugLog('Will wait for debugger');
+    debugLog();
     inspector.open(0, undefined, true);
-    debugLog('Got debugger');
+    debugLog();
   }
 })();

--- a/src/targets/node/bootloader.ts
+++ b/src/targets/node/bootloader.ts
@@ -5,6 +5,7 @@ import * as inspector from 'inspector';
 import { writeFileSync } from 'fs';
 import { spawnWatchdog } from './watchdogSpawn';
 import { IProcessTelemetry } from './nodeLauncherBase';
+import { LeaseFile } from './lease-file';
 
 function debugLog() {
   // require('fs').appendFileSync(require('path').join(require('os').homedir(), 'bootloader.txt'), `BOOTLOADER [${process.pid}] ${text}\n`);
@@ -13,6 +14,12 @@ function debugLog() {
 (function() {
   debugLog();
   if (!process.env.NODE_INSPECTOR_IPC) return;
+
+  const leaseFile = process.env.NODE_INSPECTOR_REQUIRE_LEASE;
+  if (leaseFile && !LeaseFile.isValid(leaseFile)) {
+    process.env.NODE_INSPECTOR_IPC = undefined; // save work for any children
+    return;
+  }
 
   // Electron support
   // Do not enable for Electron and other hybrid environments.

--- a/src/targets/node/lease-file.ts
+++ b/src/targets/node/lease-file.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as path from 'path';
+import { tmpdir } from 'os';
+import { randomBytes } from 'crypto';
+import { Disposable } from '../../common/events';
+import { unlinkSync, existsSync, readFileSync, writeFileSync } from 'fs';
+
+/**
+ * File that stores a lease on the filesystem. Can be validated to ensure
+ * that the file is still 'held' by someone.
+ */
+export class LeaseFile implements Disposable {
+  private static readonly updateInterval = 1000;
+  private static readonly recencyDeadline = 2000;
+
+  /**
+   * Path of the callback file.
+   */
+  public readonly path = path.join(
+    tmpdir(),
+    `node-debug-callback-${randomBytes(8).toString('hex')}`,
+  );
+
+  /**
+   * Update timer.
+   */
+  private updateInterval: NodeJS.Timer;
+
+  constructor() {
+    this.touch();
+    this.updateInterval = setInterval(() => this.touch(), LeaseFile.updateInterval);
+  }
+
+  /**
+   * Returns whether the given file path points to a valid lease.
+   */
+  public static isValid(file: string) {
+    try {
+      return Number(readFileSync(file, 'utf-8')) > Date.now() - LeaseFile.recencyDeadline;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Updates the leased file.
+   */
+  public touch() {
+    writeFileSync(this.path, String(Date.now()));
+  }
+
+  /**
+   * Diposes of the callback file.
+   */
+  public dispose() {
+    clearInterval(this.updateInterval);
+    try {
+      unlinkSync(this.path);
+    } catch {
+      // ignored
+    }
+  }
+}

--- a/src/targets/node/nodeAttacher.ts
+++ b/src/targets/node/nodeAttacher.ts
@@ -8,8 +8,11 @@ import { getWSEndpoint } from '../browser/launcher';
 import { spawnWatchdog } from './watchdogSpawn';
 import { NodeLauncherBase, IRunData } from './nodeLauncherBase';
 import { findInPath } from '../../common/pathUtils';
-import { Socket } from 'net';
 import { SubprocessProgram } from './program';
+import Cdp from '../../cdp/api';
+import { isLoopback } from '../../common/urlUtils';
+import { INodeTargetLifecycleHooks } from './nodeTarget';
+import { LeaseFile } from './lease-file';
 
 /**
  * Attaches to ongoing Node processes. This works pretty similar to the
@@ -19,6 +22,13 @@ import { SubprocessProgram } from './program';
  * child processes operate just like those we boot with the NodeLauncher.
  */
 export class NodeAttacher extends NodeLauncherBase<INodeAttachConfiguration> {
+  /**
+   * Tracker for whether we're waiting to break and instrument into the main
+   * process. This is used to avoid instrumenting unecessarily into subsequent
+   * children.
+   */
+  private capturedBreaker = false;
+
   /**
    * @inheritdoc
    */
@@ -46,5 +56,100 @@ export class NodeAttacher extends NodeLauncherBase<INodeAttachConfiguration> {
         this.onProgramTerminated(result);
       }
     });
+
+    this.capturedBreaker = false;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected createLifecycle(
+    cdp: Cdp.Api,
+    run: IRunData<INodeAttachConfiguration>,
+  ): INodeTargetLifecycleHooks {
+    if (this.capturedBreaker) {
+      return {};
+    }
+
+    // We use a lease file to indicate to the process that the debugger is
+    // still running. This is needed because once we attach, we set the
+    // NODE_OPTIONS for the process, forever. We can try to unset this on
+    // close, but this isn't reliable as it's always possible
+    const leaseFile = new LeaseFile();
+
+    let hitFirstBreakpoint = false;
+    this.capturedBreaker = true;
+
+    return {
+      initialized: async () => {
+        await cdp.Debugger.pause({});
+      },
+      paused: async (_target, ev) => {
+        if (hitFirstBreakpoint) {
+          return false;
+        }
+
+        hitFirstBreakpoint = true;
+        await Promise.all([
+          this.gatherTelemetry(cdp),
+          this.setEnvironmentVariables(cdp, run, leaseFile.path),
+        ]);
+        await cdp.Debugger.resume({});
+
+        return true;
+      },
+      close: async () => {
+        leaseFile.dispose();
+      },
+    };
+  }
+
+  private async setEnvironmentVariables(
+    cdp: Cdp.Api,
+    run: IRunData<INodeAttachConfiguration>,
+    leasePath: string,
+  ) {
+    if (!run.params.attachSpawnedProcesses) {
+      return;
+    }
+
+    if (!isLoopback(run.params.address)) {
+      // todo: logger.log("Cannot attach to children of remote process")
+      return;
+    }
+
+    const vars = this.resolveEnvironment(run).merge({
+      NODE_INSPECTOR_PPID: '0',
+      NODE_INSPECTOR_REQUIRE_LEASE: leasePath,
+    });
+
+    const result = await cdp.Runtime.evaluate({
+      contextId: 1,
+      returnByValue: true,
+      expression: `Object.assign(process.env, ${JSON.stringify(vars.defined())})`,
+    });
+
+    if (!result || result.exceptionDetails) {
+      // todo: log error assigning vars
+    }
+  }
+
+  private async gatherTelemetry(cdp: Cdp.Api) {
+    const telemetry = await cdp.Runtime.evaluate({
+      contextId: 1,
+      returnByValue: true,
+      expression: `({ processId: process.pid, nodeVersion: process.version, architecture: process.arch })`,
+    });
+
+    if (!this.program) {
+      return; // shut down
+    }
+
+    if (!telemetry || telemetry.exceptionDetails) {
+      // todo: log error getting telemetry
+      return;
+    }
+
+    this.program.gotTelemetery(telemetry.result.value);
   }
 }

--- a/src/targets/node/nodeAttacher.ts
+++ b/src/targets/node/nodeAttacher.ts
@@ -1,0 +1,45 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { AnyLaunchConfiguration, INodeAttachConfiguration } from '../../configuration';
+import { Contributions } from '../../common/contributionUtils';
+import { getWSEndpoint } from '../browser/launcher';
+import { spawnWatchdog } from './watchdogSpawn';
+import { NodeLauncherBase, IRunData } from './nodeLauncherBase';
+import { findInPath } from '../../common/pathUtils';
+import { Socket } from 'net';
+import { SubprocessProgram } from './program';
+
+/**
+ * Attaches to ongoing Node processes. This works pretty similar to the
+ * existing Node launcher, except with how we attach to the entry point:
+ * we don't have the bootloader in there, so we manually attach and enable
+ * the debugger, then evaluate and set the environment variables so that
+ * child processes operate just like those we boot with the NodeLauncher.
+ */
+export class NodeAttacher extends NodeLauncherBase<INodeAttachConfiguration> {
+  /**
+   * @inheritdoc
+   */
+  protected resolveParams(params: AnyLaunchConfiguration): INodeAttachConfiguration | undefined {
+    return params.type === Contributions.NodeDebugType && params.request === 'attach'
+      ? params
+      : undefined;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected async launchProgram(runData: IRunData<INodeAttachConfiguration>): Promise<void> {
+    const wd = spawnWatchdog(findInPath('node', process.env) || 'node', {
+      ipcAddress: runData.serverAddress,
+      scriptName: 'Remote Process',
+      inspectorURL: await getWSEndpoint(`http://${runData.params.address}:${runData.params.port}`),
+      waitForDebugger: true,
+      dynamicAttach: true,
+    });
+
+    this.program = new SubprocessProgram(wd);
+  }
+}

--- a/src/targets/node/nodeAttacher.ts
+++ b/src/targets/node/nodeAttacher.ts
@@ -40,6 +40,11 @@ export class NodeAttacher extends NodeLauncherBase<INodeAttachConfiguration> {
       dynamicAttach: true,
     });
 
-    this.program = new SubprocessProgram(wd);
+    const program = (this.program = new SubprocessProgram(wd));
+    this.program.stopped.then(result => {
+      if (program === this.program) {
+        this.onProgramTerminated(result);
+      }
+    });
   }
 }

--- a/src/targets/node/nodeLauncher.ts
+++ b/src/targets/node/nodeLauncher.ts
@@ -8,6 +8,10 @@ import { CallbackFile } from './callback-file';
 import { RestartPolicyFactory, IRestartPolicy } from './restartPolicy';
 import { delay } from '../../common/promiseUtil';
 import { NodeLauncherBase, IProcessTelemetry, IRunData } from './nodeLauncherBase';
+import { NodeTarget, INodeTargetLifecycleHooks } from './nodeTarget';
+import { absolutePathToFileUrl } from '../../common/urlUtils';
+import { resolve } from 'path';
+import Cdp from '../../cdp/api';
 
 export class NodeLauncher extends NodeLauncherBase<INodeLaunchConfiguration> {
   constructor(
@@ -91,5 +95,38 @@ export class NodeLauncher extends NodeLauncherBase<INodeLaunchConfiguration> {
     };
 
     doLaunch(this.restarters.create(runData.params));
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected createLifecycle(
+    cdp: Cdp.Api,
+    run: IRunData<INodeLaunchConfiguration>,
+    { targetId }: Cdp.Target.TargetInfo,
+  ): INodeTargetLifecycleHooks {
+    return {
+      initialized: async () => {
+        if (run.params.stopOnEntry) {
+          const params = {
+            url: absolutePathToFileUrl(resolve(run.params.cwd, run.params.program)),
+            lineNumber: 0,
+            columnNumber: 0,
+          };
+
+          await cdp.Debugger.setBreakpointByUrl(params);
+        }
+      },
+      close: () => {
+        const processId = Number(targetId);
+        if (processId > 0) {
+          try {
+            process.kill(processId);
+          } catch (e) {
+            // ignored
+          }
+        }
+      },
+    };
   }
 }

--- a/src/targets/node/nodeLauncher.ts
+++ b/src/targets/node/nodeLauncher.ts
@@ -1,349 +1,95 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import * as net from 'net';
-import * as os from 'os';
-import * as path from 'path';
-import * as fs from 'fs';
-import { EventEmitter } from '../../common/events';
-import Cdp from '../../cdp/api';
-import Connection from '../../cdp/connection';
-import { PipeTransport } from '../../cdp/transport';
-import {
-  Launcher,
-  Target,
-  LaunchResult,
-  ILaunchContext,
-  IStopMetadata,
-} from '../../targets/targets';
-import { execFileSync } from 'child_process';
 import { INodeLaunchConfiguration, AnyLaunchConfiguration } from '../../configuration';
 import { Contributions } from '../../common/contributionUtils';
-import { EnvironmentVars } from '../../common/environmentVars';
-import { NodeTarget } from './nodeTarget';
-import { NodeSourcePathResolver } from './nodeSourcePathResolver';
-import { IProgram } from './program';
-import { ProtocolError, cannotLoadEnvironmentVars } from '../../dap/errors';
 import { IProgramLauncher } from './processLauncher';
 import { CallbackFile } from './callback-file';
-import { RestartPolicyFactory } from './restartPolicy';
+import { RestartPolicyFactory, IRestartPolicy } from './restartPolicy';
 import { delay } from '../../common/promiseUtil';
+import { NodeLauncherBase, IProcessTelemetry, IRunData } from './nodeLauncherBase';
 
-/**
- * Telemetry received from the nested process.
- */
-export interface IProcessTelemetry {
-  /**
-   * Target process ID.
-   */
-  processId: number;
-
-  /**
-   * Process node version.
-   */
-  nodeVersion: string;
-
-  /**
-   * CPU architecture.
-   */
-  architecture: string;
-}
-
-let counter = 0;
-
-export class NodeLauncher implements Launcher {
-  private _server: net.Server | undefined;
-  private _connections: Connection[] = [];
-  private _launchParams?: INodeLaunchConfiguration;
-  private _pipe: string | undefined;
-  _targets = new Map<string, NodeTarget>();
-  _pathResolver?: NodeSourcePathResolver;
-  public context?: ILaunchContext;
-  private _onTerminatedEmitter = new EventEmitter<IStopMetadata>();
-  readonly onTerminated = this._onTerminatedEmitter.event;
-  _onTargetListChangedEmitter = new EventEmitter<void>();
-  readonly onTargetListChanged = this._onTargetListChangedEmitter.event;
-
-  /**
-   * The currently running program. Set to undefined if there's no process
-   * running.
-   */
-  private program?: IProgram;
-
+export class NodeLauncher extends NodeLauncherBase<INodeLaunchConfiguration> {
   constructor(
     private readonly launchers: ReadonlyArray<IProgramLauncher>,
     private readonly restarters = new RestartPolicyFactory(),
-  ) {}
+  ) {
+    super();
+  }
 
   /**
    * @inheritdoc
    */
-  public async launch(
-    params: AnyLaunchConfiguration,
-    context: ILaunchContext,
-  ): Promise<LaunchResult> {
+  protected resolveParams(params: AnyLaunchConfiguration): INodeLaunchConfiguration | undefined {
+    if (params.type === Contributions.NodeDebugType && params.request === 'launch') {
+      return params;
+    }
+
     if (
       params.type === Contributions.ChromeDebugType &&
       params.request === 'launch' &&
       params.server
     ) {
-      params = params.server;
-    } else if (params.type !== Contributions.NodeDebugType || params.request !== 'launch') {
-      return { blockSessionTermination: false };
+      return params.server;
     }
 
-    this._launchParams = params;
-    this._pathResolver = new NodeSourcePathResolver({
-      basePath: this._launchParams.cwd,
-      sourceMapOverrides: this._launchParams.sourceMapPathOverrides,
-      remoteRoot: this._launchParams.remoteRoot,
-      localRoot: this._launchParams.localRoot,
-    });
-    this.context = context;
-    this._startServer(this._launchParams);
-    await this.launchProgram(this._launchParams);
-    return { blockSessionTermination: true };
-  }
-
-  /**
-   * @inheritdoc
-   */
-  public async terminate(): Promise<void> {
-    if (this.program) {
-      await this.program.stop(); // will stop the server when it's done, in launchProgram
-    } else {
-      this._stopServer();
-    }
-  }
-
-  /**
-   * @inheritdoc
-   */
-  public async disconnect(): Promise<void> {
-    this.terminate();
-  }
-
-  /**
-   * Restarts the ongoing program.
-   */
-  public async restart(): Promise<void> {
-    if (!this._launchParams) {
-      return;
-    }
-
-    // connections must be closed, or the process will wait forever:
-    this.closeAllConnections();
-
-    // relaunch the program:
-    await this.launchProgram(this._launchParams);
+    return undefined;
   }
 
   /**
    * Launches the program.
    */
-  private async launchProgram(
-    params: INodeLaunchConfiguration,
-    restartPolicy = this.restarters.create(params),
-  ): Promise<void> {
-    // Close any existing program. We intentionally don't wait for stop() to
-    // finish, since doing so will shut down the server.
-    if (this.program) {
-      this.program.stop(); // intentionally not awaited on
-    }
+  protected async launchProgram(runData: IRunData<INodeLaunchConfiguration>): Promise<void> {
+    const doLaunch = async (restartPolicy: IRestartPolicy) => {
+      // Close any existing program. We intentionally don't wait for stop() to
+      // finish, since doing so will shut down the server.
+      if (this.program) {
+        this.program.stop(); // intentionally not awaited on
+      }
 
-    const callbackFile = new CallbackFile<IProcessTelemetry>();
-    const bootloader = this.getBootloaderFile(params.cwd);
-    const options: INodeLaunchConfiguration = {
-      ...params,
-      env: this.resolveEnvironment(params, bootloader.path, callbackFile).value,
+      const callbackFile = new CallbackFile<IProcessTelemetry>();
+      const options: INodeLaunchConfiguration = {
+        ...runData.params,
+        env: this.resolveEnvironment(runData, callbackFile.path).value,
+      };
+      const launcher = this.launchers.find(l => l.canLaunch(options));
+      if (!launcher) {
+        throw new Error('Cannot find an appropriate launcher for the given set of options');
+      }
+
+      const program = (this.program = await launcher.launchProgram(options, runData.context));
+
+      // Once the program stops, dispose of the file. If we started a new program
+      // in the meantime, don't do anything. Otherwise, restart if we need to,
+      // and if we don't then shut down the server and indicate that we terminated.
+      program.stopped.then(async result => {
+        callbackFile.dispose();
+
+        if (this.program !== program) {
+          return;
+        }
+
+        const nextRestart = restartPolicy.next(result);
+        if (!nextRestart) {
+          this.onProgramTerminated(result);
+          return;
+        }
+
+        await delay(nextRestart.delay);
+        if (this.program === program) {
+          doLaunch(nextRestart);
+        }
+      });
+
+      // Read the callback file, and signal the running program when we read
+      // data. read() retur
+      callbackFile.read().then(data => {
+        if (data) {
+          program.gotTelemetery(data);
+        }
+      });
     };
-    const launcher = this.launchers.find(l => l.canLaunch(options));
-    if (!launcher) {
-      throw new Error('Cannot find an appropriate launcher for the given set of options');
-    }
 
-    const program = (this.program = await launcher.launchProgram(options, this.context!));
-
-    // Once the program stops, dispose of the file. If we started a new program
-    // in the meantime, don't do anything. Otherwise, restart if we need to,
-    // and if we don't then shut down the server and indicate that we terminated.
-    program.stopped.then(async result => {
-      callbackFile.dispose();
-      bootloader.dispose();
-
-      if (this.program !== program) {
-        return;
-      }
-
-      const nextRestart = restartPolicy.next(result);
-      if (!nextRestart) {
-        this._onTerminatedEmitter.fire(result);
-        this._stopServer();
-        this.program = undefined;
-        return;
-      }
-
-      await delay(nextRestart.delay);
-      if (this.program === program) {
-        this.launchProgram(params, nextRestart);
-      }
-    });
-
-    // Read the callback file, and signal the running program when we read
-    // data. read() retur
-    callbackFile.read().then(data => {
-      if (data) {
-        program.gotTelemetery(data);
-      }
-    });
+    doLaunch(this.restarters.create(runData.params));
   }
-
-  /**
-   * Returns the file from which to load our bootloader. We need to do this in
-   * since Node does not support paths with spaces in them < 13 (nodejs/node#12971),
-   * so if our installation path has spaces, we need to fall back somewhere.
-   */
-  private getBootloaderFile(cwd: string) {
-    const targetPath = path.join(__dirname, 'bootloader.js');
-
-    // 1. If we aren't on windows or the path doesn't have a space, we're OK to use it.
-    if (process.platform !== 'win32' || !targetPath.includes(' ')) {
-      return { path: targetPath, dispose: () => undefined };
-    }
-
-    // 2. Try the tmpdir, if it's space-free.
-    const contents = `require(${JSON.stringify(targetPath)})`;
-    if (!os.tmpdir().includes(' ')) {
-      const tmpPath = path.join(os.tmpdir(), 'vscode-pwa-bootloader.js');
-      fs.writeFileSync(tmpPath, contents);
-      return { path: tmpPath, dispose: () => fs.unlinkSync(tmpPath) };
-    }
-
-    // 3. Worst case, write into the cwd. This is messy, but we have few options.
-    const nearFilename = '.vscode-pwa-bootloader.js';
-    const nearPath = path.join(cwd, nearFilename);
-    fs.writeFileSync(nearPath, contents);
-    return { path: `./${nearFilename}`, dispose: () => fs.unlinkSync(nearPath) };
-  }
-
-  private resolveEnvironment(
-    args: INodeLaunchConfiguration,
-    bootloader: string,
-    callbackFile: CallbackFile<any>,
-  ) {
-    let base: { [key: string]: string } = {};
-
-    // read environment variables from any specified file
-    if (args.envFile) {
-      try {
-        base = readEnvFile(args.envFile);
-      } catch (e) {
-        throw new ProtocolError(cannotLoadEnvironmentVars(e.message));
-      }
-    }
-
-    const baseEnv = EnvironmentVars.merge(base, args.env);
-
-    return baseEnv.merge({
-      NODE_INSPECTOR_IPC: this._pipe || null,
-      NODE_INSPECTOR_PPID: '',
-      // todo: look at reimplementing the filter
-      // NODE_INSPECTOR_WAIT_FOR_DEBUGGER: this._launchParams!.nodeFilter || '',
-      NODE_INSPECTOR_WAIT_FOR_DEBUGGER: '',
-      // Require our bootloader first, to run it before any other bootloader
-      // we could have injected in the parent process.
-      NODE_OPTIONS: `--require ${bootloader} ${baseEnv.lookup('NODE_OPTIONS') || ''}`,
-      // Supply some node executable for running top-level watchdog in Electron
-      // environments. Bootloader will replace this with actual node executable used if any.
-      NODE_INSPECTOR_EXEC_PATH: findNode() || '',
-      VSCODE_DEBUGGER_FILE_CALLBACK: callbackFile.path,
-      VSCODE_DEBUGGER_ONLY_ENTRYPOINT: args.autoAttachChildProcesses ? 'false' : 'true',
-      ELECTRON_RUN_AS_NODE: null,
-    });
-  }
-
-  private _startServer(args: INodeLaunchConfiguration) {
-    const pipePrefix = process.platform === 'win32' ? '\\\\.\\pipe\\' : os.tmpdir();
-    this._pipe = path.join(pipePrefix, `node-cdp.${process.pid}-${++counter}.sock`);
-    this._server = net
-      .createServer(socket => {
-        this._startSession(socket, args);
-      })
-      .listen(this._pipe);
-  }
-
-  private _stopServer() {
-    if (this._server) {
-      this._server.close();
-    }
-
-    this._server = undefined;
-    this.closeAllConnections();
-  }
-
-  private closeAllConnections() {
-    this._connections.forEach(c => c.close());
-    this._connections = [];
-  }
-
-  private async _startSession(socket: net.Socket, args: INodeLaunchConfiguration) {
-    const connection = new Connection(new PipeTransport(socket));
-    this._connections.push(connection);
-    const cdp = connection.rootSession();
-    const { targetInfo } = await new Promise<Cdp.Target.TargetCreatedEvent>(f =>
-      cdp.Target.on('targetCreated', f),
-    );
-
-    new NodeTarget(this, connection, cdp, targetInfo, args);
-    this._onTargetListChangedEmitter.fire();
-  }
-
-  public targetList(): Target[] {
-    return Array.from(this._targets.values());
-  }
-
-  public dispose() {
-    this._stopServer();
-  }
-}
-
-function findNode(): string | undefined {
-  // TODO: implement this for Windows.
-  if (process.platform !== 'linux' && process.platform !== 'darwin') return;
-  try {
-    return execFileSync('which', ['node'], { stdio: 'pipe' })
-      .toString()
-      .split(/\r?\n/)[0];
-  } catch (e) {}
-}
-
-function readEnvFile(file: string): { [key: string]: string } {
-  if (!fs.existsSync(file)) {
-    return {};
-  }
-
-  const buffer = stripBOM(fs.readFileSync(file, 'utf8'));
-  const env = {};
-  for (const line of buffer.split('\n')) {
-    const r = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
-    if (!r) {
-      continue;
-    }
-
-    let [, key, value = ''] = r;
-    // .env variables never overwrite existing variables (see #21169)
-    if (value.length > 0 && value.charAt(0) === '"' && value.charAt(value.length - 1) === '"') {
-      value = value.replace(/\\n/gm, '\n');
-    }
-    env[key] = value.replace(/(^['"]|['"]$)/g, '');
-  }
-
-  return env;
-}
-
-function stripBOM(s: string): string {
-  if (s && s[0] === '\uFEFF') {
-    s = s.substr(1);
-  }
-  return s;
 }

--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -135,10 +135,10 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
    */
   public async terminate(): Promise<void> {
     if (this.program) {
-      await this.program.stop(); // will stop the server when it's done, in onProgramTerminated
-    } else {
-      this._stopServer();
+      this.program.stop();
     }
+
+    this.onProgramTerminated({ code: 0, killed: true });
   }
 
   /**

--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -18,7 +18,7 @@ import {
 } from '../../targets/targets';
 import { AnyLaunchConfiguration, AnyNodeConfiguration } from '../../configuration';
 import { EnvironmentVars } from '../../common/environmentVars';
-import { NodeTarget } from './nodeTarget';
+import { INodeTargetLifecycleHooks, NodeTarget } from './nodeTarget';
 import { NodeSourcePathResolver } from './nodeSourcePathResolver';
 import { IProgram } from './program';
 import { ProtocolError, cannotLoadEnvironmentVars } from '../../dap/errors';
@@ -236,6 +236,13 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
     });
   }
 
+  /**
+   * Logic run when a thread is created.
+   */
+  protected createLifecycle(_cdp: Cdp.Api, _run: IRunData<T>, _target: Cdp.Target.TargetInfo): INodeTargetLifecycleHooks {
+    return {};
+  }
+
   protected _startServer() {
     const pipePrefix = process.platform === 'win32' ? '\\\\.\\pipe\\' : os.tmpdir();
     const pipe = path.join(pipePrefix, `node-cdp.${process.pid}-${++counter}.sock`);
@@ -274,6 +281,7 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
       cdp,
       targetInfo,
       this.run.params,
+      this.createLifecycle(cdp, this.run, targetInfo),
     );
 
     target.setParent(targetInfo.openerId ? this.targets.get(targetInfo.openerId) : undefined);

--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -1,0 +1,357 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+import * as net from 'net';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+import { EventEmitter, Disposable } from '../../common/events';
+import Cdp from '../../cdp/api';
+import Connection from '../../cdp/connection';
+import { PipeTransport } from '../../cdp/transport';
+import {
+  Launcher,
+  Target,
+  LaunchResult,
+  ILaunchContext,
+  IStopMetadata,
+} from '../../targets/targets';
+import { AnyLaunchConfiguration, AnyNodeConfiguration } from '../../configuration';
+import { EnvironmentVars } from '../../common/environmentVars';
+import { NodeTarget } from './nodeTarget';
+import { NodeSourcePathResolver } from './nodeSourcePathResolver';
+import { IProgram } from './program';
+import { ProtocolError, cannotLoadEnvironmentVars } from '../../dap/errors';
+import { ObservableMap } from '../targetList';
+import { findInPath } from '../../common/pathUtils';
+
+/**
+ * Telemetry received from the nested process.
+ */
+export interface IProcessTelemetry {
+  /**
+   * Target process ID.
+   */
+  processId: number;
+
+  /**
+   * Process node version.
+   */
+  nodeVersion: string;
+
+  /**
+   * CPU architecture.
+   */
+  architecture: string;
+}
+
+type BootloaderFile = Disposable & { path: string };
+
+/**
+ * Data stored for a currently running debug session within the Node launcher.
+ */
+export interface IRunData<T> {
+  server: net.Server;
+  serverAddress: string;
+  bootloader: BootloaderFile;
+  pathResolver: NodeSourcePathResolver;
+  context: ILaunchContext;
+  params: T;
+}
+
+let counter = 0;
+
+export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implements Launcher {
+  /**
+   * Data set while a debug session is running.
+   */
+  private run?: IRunData<T>;
+
+  /**
+   * Attached server connections. Tracked so they can be torn down readily.
+   */
+  private serverConnections: Connection[] = [];
+
+  /**
+   * Target list.
+   */
+  private readonly targets = new ObservableMap<NodeTarget>();
+
+  /**
+   * Underlying emitter fired when sessions terminate. Listened to by the
+   * binder and used to trigger a `terminate` message on the DAP.
+   */
+  private onTerminatedEmitter = new EventEmitter<IStopMetadata>();
+
+  /**
+   * @inheritdoc
+   */
+  public readonly onTerminated = this.onTerminatedEmitter.event;
+
+  /**
+   * @inheritdoc
+   */
+  public readonly onTargetListChanged = this.targets.onChanged;
+
+  /**
+   * The currently running program. Set to undefined if there's no process
+   * running.
+   */
+  protected program?: IProgram;
+
+  /**
+   * @inheritdoc
+   */
+  public async launch(
+    params: AnyLaunchConfiguration,
+    context: ILaunchContext,
+  ): Promise<LaunchResult> {
+    const resolved = this.resolveParams(params);
+    if (!resolved) {
+      return { blockSessionTermination: false };
+    }
+
+    const { server, pipe } = this._startServer();
+    const run = (this.run = {
+      server,
+      serverAddress: pipe,
+      params: resolved,
+      context,
+      bootloader: this.getBootloaderFile(resolved.cwd),
+      pathResolver: new NodeSourcePathResolver({
+        basePath: resolved.cwd,
+        sourceMapOverrides: resolved.sourceMapPathOverrides,
+        remoteRoot: resolved.remoteRoot,
+        localRoot: resolved.localRoot,
+      }),
+    });
+
+    await this.launchProgram(run);
+    return { blockSessionTermination: true };
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public async terminate(): Promise<void> {
+    if (this.program) {
+      await this.program.stop(); // will stop the server when it's done, in onProgramTerminated
+    } else {
+      this._stopServer();
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public async disconnect(): Promise<void> {
+    this.terminate();
+  }
+
+  /**
+   * Restarts the ongoing program.
+   */
+  public async restart(): Promise<void> {
+    if (!this.run) {
+      return;
+    }
+
+    // connections must be closed, or the process will wait forever:
+    this.closeAllConnections();
+
+    // relaunch the program:
+    await this.launchProgram(this.run);
+  }
+
+  public targetList(): Target[] {
+    return this.targets.value();
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public dispose() {
+    this._stopServer();
+  }
+
+  /**
+   * Returns the params type if they can be launched by this launcher,
+   * or undefined if they cannot.
+   */
+  protected abstract resolveParams(params: AnyLaunchConfiguration): T | undefined;
+
+  /**
+   * Launches the program. Called after the server is running and upon restart.
+   */
+  protected abstract launchProgram(runData: IRunData<T>): Promise<void>;
+
+  /**
+   * Method that should be called when the program from launchProgram() exits.
+   * Emits a stop to the client and tears down the server.
+   */
+  protected onProgramTerminated(result: IStopMetadata) {
+    this.onTerminatedEmitter.fire(result);
+    this._stopServer();
+    this.program = undefined;
+  }
+
+  /**
+   * Gets the environment variables for the session.
+   */
+  protected resolveEnvironment(
+    { params, serverAddress, bootloader }: IRunData<T>,
+    callbackFile?: string,
+  ) {
+    const anyParams = params as any;
+    let baseEnv = EnvironmentVars.empty;
+
+    // read environment variables from any specified file
+    if ('envFile' in params && anyParams.envFile) {
+      try {
+        baseEnv = baseEnv.merge(readEnvFile(anyParams.envFile));
+      } catch (e) {
+        throw new ProtocolError(cannotLoadEnvironmentVars(e.message));
+      }
+    }
+
+    if ('env' in params) {
+      baseEnv = baseEnv.merge(anyParams.env);
+    }
+
+    return baseEnv.merge({
+      NODE_INSPECTOR_IPC: serverAddress,
+      NODE_INSPECTOR_PPID: '',
+      // todo: look at reimplementing the filter
+      // NODE_INSPECTOR_WAIT_FOR_DEBUGGER: this._launchParams!.nodeFilter || '',
+      NODE_INSPECTOR_WAIT_FOR_DEBUGGER: '',
+      // Require our bootloader first, to run it before any other bootloader
+      // we could have injected in the parent process.
+      NODE_OPTIONS: `--require ${bootloader.path} ${baseEnv.lookup('NODE_OPTIONS') || ''}`,
+      // Supply some node executable for running top-level watchdog in Electron
+      // environments. Bootloader will replace this with actual node executable used if any.
+      NODE_INSPECTOR_EXEC_PATH: findInPath('node', process.env) || '',
+      VSCODE_DEBUGGER_FILE_CALLBACK: callbackFile,
+      VSCODE_DEBUGGER_ONLY_ENTRYPOINT: params.autoAttachChildProcesses ? 'false' : 'true',
+      ELECTRON_RUN_AS_NODE: null,
+    });
+  }
+
+  protected _startServer() {
+    const pipePrefix = process.platform === 'win32' ? '\\\\.\\pipe\\' : os.tmpdir();
+    const pipe = path.join(pipePrefix, `node-cdp.${process.pid}-${++counter}.sock`);
+    const server = net.createServer(socket => this._startSession(socket)).listen(pipe);
+
+    return { pipe, server };
+  }
+
+  protected _stopServer() {
+    if (this.run) {
+      this.run.server.close();
+      this.run.bootloader.dispose();
+    }
+
+    this.run = undefined;
+    this.closeAllConnections();
+  }
+
+  protected closeAllConnections() {
+    this.serverConnections.forEach(c => c.close());
+    this.serverConnections = [];
+  }
+
+  protected async _startSession(socket: net.Socket) {
+    const { connection, cdp, targetInfo } = await this.acquireTarget(socket);
+    if (!this.run) {
+      // if we aren't running a session, discard the socket.
+      socket.destroy();
+      return;
+    }
+
+    const target = new NodeTarget(
+      this.run.pathResolver,
+      this.run.context.targetOrigin,
+      connection,
+      cdp,
+      targetInfo,
+      this.run.params,
+    );
+
+    target.setParent(targetInfo.openerId ? this.targets.get(targetInfo.openerId) : undefined);
+    this.targets.add(targetInfo.targetId, target);
+    target.onDisconnect(() => this.targets.remove(targetInfo.targetId));
+  }
+
+  /**
+   * Acquires the CDP session and target info from the connecting socket.
+   */
+
+  protected async acquireTarget(socket: net.Socket) {
+    const connection = new Connection(new PipeTransport(socket));
+    this.serverConnections.push(connection);
+    const cdp = connection.rootSession();
+    const { targetInfo } = await new Promise<Cdp.Target.TargetCreatedEvent>(f =>
+      cdp.Target.on('targetCreated', f),
+    );
+
+    return { targetInfo, cdp, connection };
+  }
+
+  /**
+   * Returns the file from which to load our bootloader. We need to do this in
+   * since Node does not support paths with spaces in them < 13 (nodejs/node#12971),
+   * so if our installation path has spaces, we need to fall back somewhere.
+   */
+  private getBootloaderFile(cwd: string) {
+    const targetPath = path.join(__dirname, 'bootloader.js');
+
+    // 1. If we aren't on windows or the path doesn't have a space, we're OK to use it.
+    if (process.platform !== 'win32' || !targetPath.includes(' ')) {
+      return { path: targetPath, dispose: () => undefined };
+    }
+
+    // 2. Try the tmpdir, if it's space-free.
+    const contents = `require(${JSON.stringify(targetPath)})`;
+    if (!os.tmpdir().includes(' ')) {
+      const tmpPath = path.join(os.tmpdir(), 'vscode-pwa-bootloader.js');
+      fs.writeFileSync(tmpPath, contents);
+      return { path: tmpPath, dispose: () => fs.unlinkSync(tmpPath) };
+    }
+
+    // 3. Worst case, write into the cwd. This is messy, but we have few options.
+    const nearFilename = '.vscode-pwa-bootloader.js';
+    const nearPath = path.join(cwd, nearFilename);
+    fs.writeFileSync(nearPath, contents);
+    return { path: `./${nearFilename}`, dispose: () => fs.unlinkSync(nearPath) };
+  }
+}
+
+function readEnvFile(file: string): { [key: string]: string } {
+  if (!fs.existsSync(file)) {
+    return {};
+  }
+
+  const buffer = stripBOM(fs.readFileSync(file, 'utf8'));
+  const env = {};
+  for (const line of buffer.split('\n')) {
+    const r = line.match(/^\s*([\w\.\-]+)\s*=\s*(.*)?\s*$/);
+    if (!r) {
+      continue;
+    }
+
+    let [, key, value = ''] = r;
+    // .env variables never overwrite existing variables (see #21169)
+    if (value.length > 0 && value.charAt(0) === '"' && value.charAt(value.length - 1) === '"') {
+      value = value.replace(/\\n/gm, '\n');
+    }
+    env[key] = value.replace(/(^['"]|['"]$)/g, '');
+  }
+
+  return env;
+}
+
+function stripBOM(s: string): string {
+  if (s && s[0] === '\uFEFF') {
+    s = s.substr(1);
+  }
+  return s;
+}

--- a/src/targets/node/nodeTarget.ts
+++ b/src/targets/node/nodeTarget.ts
@@ -3,17 +3,15 @@
  *--------------------------------------------------------*/
 
 import { Target } from '../targets';
-import { NodeLauncher } from './nodeLauncher';
 import Cdp from '../../cdp/api';
 import Connection from '../../cdp/connection';
-import { INodeLaunchConfiguration } from '../../configuration';
+import { AnyNodeConfiguration } from '../../configuration';
 import { InlineScriptOffset, ISourcePathResolver } from '../../common/sourcePathResolver';
 import { EventEmitter } from '../../common/events';
 import { absolutePathToFileUrl } from '../../common/urlUtils';
 import { basename } from 'path';
 
 export class NodeTarget implements Target {
-  private _launcher: NodeLauncher;
   private _cdp: Cdp.Api;
   private _parent: NodeTarget | undefined;
   private _children: NodeTarget[] = [];
@@ -24,16 +22,19 @@ export class NodeTarget implements Target {
   private _attached = false;
   private _waitingForDebugger: boolean;
   private _onNameChangedEmitter = new EventEmitter<void>();
-  readonly onNameChanged = this._onNameChangedEmitter.event;
+  private _onDisconnectEmitter = new EventEmitter<void>();
+
+  public readonly onDisconnect = this._onDisconnectEmitter.event;
+  public readonly onNameChanged = this._onNameChangedEmitter.event;
 
   constructor(
-    launcher: NodeLauncher,
+    private readonly pathResolver: ISourcePathResolver,
+    private readonly targetOriginValue: string,
     public readonly connection: Connection,
     cdp: Cdp.Api,
     targetInfo: Cdp.Target.TargetInfo,
-    args: INodeLaunchConfiguration,
+    args: AnyNodeConfiguration,
   ) {
-    this._launcher = launcher;
     this.connection = connection;
     this._cdp = cdp;
     this._targetId = targetInfo.targetId;
@@ -45,8 +46,6 @@ export class NodeTarget implements Target {
     if (args.logging && args.logging.cdp)
       connection.setLogConfig(this._targetName, args.logging.cdp);
 
-    this._setParent(launcher._targets.get(targetInfo.openerId!));
-    launcher._targets.set(targetInfo.targetId, this);
     cdp.Target.on('targetDestroyed', () => this.connection.close());
     connection.onDisconnected(_ => this._disconnected());
   }
@@ -68,7 +67,7 @@ export class NodeTarget implements Target {
   }
 
   targetOrigin(): any {
-    return this._launcher.context!.targetOrigin;
+    return this.targetOriginValue;
   }
 
   parent(): Target | undefined {
@@ -98,7 +97,7 @@ export class NodeTarget implements Target {
   }
 
   sourcePathResolver(): ISourcePathResolver {
-    return this._launcher._pathResolver!;
+    return this.pathResolver;
   }
 
   supportsCustomBreakpoints(): boolean {
@@ -118,18 +117,16 @@ export class NodeTarget implements Target {
     return !!this._parent;
   }
 
-  _setParent(parent?: NodeTarget) {
+  public setParent(parent?: NodeTarget) {
     if (this._parent) this._parent._children.splice(this._parent._children.indexOf(this), 1);
     this._parent = parent;
     if (this._parent) this._parent._children.push(this);
   }
 
   async _disconnected() {
-    this._children.forEach(child => child._setParent(this._parent));
-    this._setParent(undefined);
-    this._launcher._targets.delete(this._targetId);
-    // await this.detach();
-    this._launcher._onTargetListChangedEmitter.fire();
+    this._children.forEach(child => child.setParent(this._parent));
+    this.setParent(undefined);
+    this._onDisconnectEmitter.fire();
   }
 
   canAttach(): boolean {
@@ -147,7 +144,12 @@ export class NodeTarget implements Target {
   async _doAttach(): Promise<Cdp.Api> {
     this._waitingForDebugger = false;
     this._attached = true;
-    await this._cdp.Target.attachToTarget({ targetId: this._targetId });
+    const result = await this._cdp.Target.attachToTarget({ targetId: this._targetId });
+    if (result && '__dynamicAttach' in result) {
+      await this._cdp.Debugger.enable({});
+      await this._cdp.Runtime.enable({});
+    }
+
     let defaultCountextId: number;
     this._cdp.Runtime.on('executionContextCreated', event => {
       if (event.context.auxData && event.context.auxData['isDefault'])

--- a/src/targets/node/nodeTarget.ts
+++ b/src/targets/node/nodeTarget.ts
@@ -37,6 +37,7 @@ export class NodeTarget implements Target {
   ) {
     this.connection = connection;
     this._cdp = cdp;
+    cdp.pause();
     this._targetId = targetInfo.targetId;
     this._scriptName = targetInfo.title;
     this._waitingForDebugger = targetInfo.type === 'waitingForDebugger';
@@ -161,6 +162,10 @@ export class NodeTarget implements Target {
     return this._cdp;
   }
 
+  public async afterBind() {
+    this._cdp.resume();
+  }
+
   canDetach(): boolean {
     return this._attached;
   }
@@ -188,9 +193,15 @@ export class NodeTarget implements Target {
   }
 
   stop() {
-    try {
-      process.kill(+this._targetId);
-    } catch (e) {}
+    const processId = Number(this._targetId);
+    if (processId > 0) {
+      try {
+        process.kill(+this._targetId);
+      } catch (e) {
+        // ignored
+      }
+    }
+
     this.connection.close();
   }
 }

--- a/src/targets/node/nodeTarget.ts
+++ b/src/targets/node/nodeTarget.ts
@@ -11,6 +11,25 @@ import { EventEmitter } from '../../common/events';
 import { absolutePathToFileUrl } from '../../common/urlUtils';
 import { basename } from 'path';
 
+export interface INodeTargetLifecycleHooks {
+  /**
+   * Invoked when the adapter thread is first initialized.
+   */
+
+  initialized?(target: NodeTarget): Promise<void>;
+
+  /**
+   * Invoked when the thread is paused. Return true if the pause event
+   * is handled internally and should not be returned to the UI.
+   */
+  paused?(target: NodeTarget, notification: Cdp.Debugger.PausedEvent): Promise<boolean>;
+
+  /**
+   * Invoked when the target is stopped.
+   */
+  close?(target: NodeTarget): void;
+}
+
 export class NodeTarget implements Target {
   private _cdp: Cdp.Api;
   private _parent: NodeTarget | undefined;
@@ -34,6 +53,7 @@ export class NodeTarget implements Target {
     cdp: Cdp.Api,
     targetInfo: Cdp.Target.TargetInfo,
     args: AnyNodeConfiguration,
+    private readonly lifecycle: INodeTargetLifecycleHooks = {},
   ) {
     this.connection = connection;
     this._cdp = cdp;
@@ -77,6 +97,16 @@ export class NodeTarget implements Target {
 
   children(): Target[] {
     return Array.from(this._children.values());
+  }
+
+  public async initialize() {
+    if (this.lifecycle.initialized) {
+      this.lifecycle.initialized(this);
+    }
+  }
+
+  public async onPaused(event: Cdp.Debugger.PausedEvent) {
+    return !!this.lifecycle.paused && (await this.lifecycle.paused(this, event));
   }
 
   waitingForDebugger(): boolean {
@@ -193,16 +223,13 @@ export class NodeTarget implements Target {
   }
 
   stop() {
-    const processId = Number(this._targetId);
-    if (processId > 0) {
-      try {
-        process.kill(+this._targetId);
-      } catch (e) {
-        // ignored
+    try {
+      if (this.lifecycle.close) {
+        this.lifecycle.close(this);
       }
+    } finally {
+      this.connection.close();
     }
-
-    this.connection.close();
   }
 }
 

--- a/src/targets/node/program.ts
+++ b/src/targets/node/program.ts
@@ -29,7 +29,7 @@ export class SubprocessProgram implements IProgram {
   public readonly stopped: Promise<IStopMetadata>;
   private killed = false;
 
-  constructor(private child: ChildProcess) {
+  constructor(private readonly child: ChildProcess) {
     this.stopped = new Promise((resolve, reject) => {
       child.once('exit', code => resolve({ killed: this.killed, code: code || 0 }));
       child.once('error', error => reject({ killed: this.killed, code: 1, error }));

--- a/src/targets/node/program.ts
+++ b/src/targets/node/program.ts
@@ -2,11 +2,11 @@
  * Copyright (C) Microsoft Corporation. All rights reserved.
  *--------------------------------------------------------*/
 
-import { IProcessTelemetry } from './nodeLauncher';
 import { ChildProcess } from 'child_process';
 import { killTree } from './killTree';
 import Dap from '../../dap/api';
 import { IStopMetadata } from '../targets';
+import { IProcessTelemetry } from './nodeLauncherBase';
 
 export interface IProgram {
   readonly stopped: Promise<IStopMetadata>;

--- a/src/targets/node/watchdog.ts
+++ b/src/targets/node/watchdog.ts
@@ -8,7 +8,7 @@ import { IWatchdogInfo } from './watchdogSpawn';
 const info: IWatchdogInfo = JSON.parse(process.env.NODE_INSPECTOR_INFO!);
 
 function debugLog(text: string) {
-  require('fs').appendFileSync(require('path').join(require('os').homedir(), 'watchdog.txt'), `WATCHDOG [${info.pid}] ${text} (${info.scriptName})\n`);
+  // require('fs').appendFileSync(require('path').join(require('os').homedir(), 'watchdog.txt'), `WATCHDOG [${info.pid}] ${text} (${info.scriptName})\n`);
 }
 
 process.on('exit', () => {

--- a/src/targets/node/watchdog.ts
+++ b/src/targets/node/watchdog.ts
@@ -3,32 +3,34 @@
 
 import * as net from 'net';
 import { WebSocketTransport, PipeTransport } from '../../cdp/transport';
+import { IWatchdogInfo } from './watchdogSpawn';
 
-const info = JSON.parse(process.env.NODE_INSPECTOR_INFO!);
-
+const info: IWatchdogInfo = JSON.parse(process.env.NODE_INSPECTOR_INFO!);
 
 function debugLog(text: string) {
-  // require('fs').appendFileSync(require('path').join(require('os').homedir(), 'watchdog.txt'), `WATCHDOG [${info.pid}] ${text} (${info.scriptName})\n`);
+  require('fs').appendFileSync(require('path').join(require('os').homedir(), 'watchdog.txt'), `WATCHDOG [${info.pid}] ${text} (${info.scriptName})\n`);
 }
 
 process.on('exit', () => {
   debugLog('KILL');
-  process.kill(+info.pid);
+  if (info.pid) {
+    process.kill(Number(info.pid));
+  }
 });
 
-(async() => {
+(async () => {
   debugLog('CONNECTED TO TARGET');
   let server: PipeTransport;
   let pipe: any;
-  await new Promise(f => pipe = net.createConnection(process.env.NODE_INSPECTOR_IPC!, f));
+  await new Promise(f => (pipe = net.createConnection(process.env.NODE_INSPECTOR_IPC!, f)));
   server = new PipeTransport(pipe);
 
   const targetInfo = {
-    targetId: info.pid,
+    targetId: info.pid || '0',
     type: info.waitForDebugger ? 'waitingForDebugger' : '',
     title: info.scriptName,
     url: 'file://' + info.scriptName,
-    openerId: info.ppid
+    openerId: info.ppid,
   };
 
   server.send(JSON.stringify({ method: 'Target.targetCreated', params: { targetInfo } }));
@@ -42,7 +44,7 @@ process.on('exit', () => {
       return;
     }
 
-    let result = {};
+    let result: any = {};
     const object = JSON.parse(data);
 
     if (object.method === 'Target.attachToTarget') {
@@ -54,10 +56,19 @@ process.on('exit', () => {
       target = await WebSocketTransport.create(info.inspectorURL);
       target.onmessage = data => server.send(data);
       target.onclose = () => {
-        if (target)  // Could be due us closing.
-          server.send(JSON.stringify({ method: 'Target.targetDestroyed', params: { targetId: info.pid, sessionId: info.pid } }));
+        if (target)
+          // Could be due us closing.
+          server.send(
+            JSON.stringify({
+              method: 'Target.targetDestroyed',
+              params: { targetId: targetInfo.targetId, sessionId: targetInfo.targetId },
+            }),
+          );
       };
-      result = { sessionId: info.pid };
+      result = { sessionId: targetInfo.targetId };
+      if (info.dynamicAttach) {
+        result.__dynamicAttach = true;
+      }
     } else if (object.method === 'Target.detachFromTarget') {
       debugLog('DETACH FROM TARGET');
       if (target) {
@@ -78,7 +89,6 @@ process.on('exit', () => {
 
   server.onclose = () => {
     debugLog('SERVER CLOSED');
-    if (target)
-      target.close();
-  }
+    if (target) target.close();
+  };
 })();

--- a/src/targets/node/watchdogSpawn.ts
+++ b/src/targets/node/watchdogSpawn.ts
@@ -1,0 +1,61 @@
+import { spawn } from 'child_process';
+import { join } from 'path';
+
+export interface IWatchdogInfo {
+  /**
+   * Observed process ID.
+   */
+  pid?: string;
+
+  /**
+   * If set to true, this indicates that the process the watchdog is monitoring
+   * was not started with the bootloader. In order to debug it, we must tell
+   * CDP to force it into debugging mode manually.
+   */
+  dynamicAttach?: boolean;
+
+  /**
+   * Process script name, for cosmetic purposes.
+   */
+  scriptName: string;
+
+  /**
+   * URL of the inspector running on the process.
+   */
+  inspectorURL: string;
+
+  /**
+   * Address on the debugging server to attach to.
+   */
+  ipcAddress: string;
+
+  /**
+   * Whether the process is waiting for the debugger to attach.
+   */
+  waitForDebugger: boolean;
+
+  /**
+   * Parent process ID.
+   */
+  ppid?: string;
+}
+
+const watchdogPath = join(__dirname, 'watchdog.js');
+
+/**
+ * Spawns a watchdog attached to the given process.
+ */
+export function spawnWatchdog(execPath: string, { ipcAddress, ...inspectorInfo }: IWatchdogInfo) {
+  const p = spawn(execPath, [watchdogPath], {
+    env: {
+      NODE_INSPECTOR_INFO: JSON.stringify(inspectorInfo),
+      NODE_INSPECTOR_IPC: ipcAddress,
+    },
+    stdio: 'ignore',
+    detached: true,
+  });
+  p.unref();
+  process.on('exit', () => p.kill());
+
+  return p;
+}

--- a/src/targets/targetList.ts
+++ b/src/targets/targetList.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------
+* Copyright (C) Microsoft Corporation. All rights reserved.
+*--------------------------------------------------------*/
+
+import { EventEmitter } from "../common/events";
+
+/**
+ * A wrapper around map that fires an event emitter when it's mutated. Used
+ * for manging lists of targets.
+ */
+export class ObservableMap<T> {
+  private readonly changeEmitter = new EventEmitter<void>();
+  private readonly targetMap = new Map<string, T>();
+
+  /**
+   * Event emitter that fires when the list of targets changes.
+   */
+  public readonly onChanged = this.changeEmitter.event;
+
+  /**
+   * Adds a new target to the list
+   */
+  public add(openerId: string, target: T) {
+    this.targetMap.set(openerId, target);
+    this.changeEmitter.fire();
+  }
+
+  /**
+   * Gets a target by opener ID.
+   */
+  public get(openerId: string): T | undefined {
+    return this.targetMap.get(openerId);
+  }
+
+  /**
+   * Removes a target by opener ID.
+   */
+  public remove(openerId: string) {
+    this.targetMap.delete(openerId);
+    this.changeEmitter.fire();
+  }
+
+  /**
+   * Returns a list of known targets.
+   */
+  public value() {
+    return Array.from(this.targetMap.values());
+  }
+}

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -29,6 +29,11 @@ export interface Target {
   canDetach(): boolean;
   detach(): Promise<void>;
   targetOrigin(): any;
+  /**
+   * Lifecycle callback invoked after attaching and the target's events are
+   * wired into the debug adapter.
+   */
+  afterBind(): Promise<void>;
 
   waitingForDebugger(): boolean;
   supportsCustomBreakpoints(): boolean;

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -35,6 +35,13 @@ export interface Target {
    */
   afterBind(): Promise<void>;
 
+  /**
+   * Handler triggered on a breakpoint. If this returns true, the UI will be
+   * continued and no breakpoint will be shown to the user.
+   */
+  onPaused(event: Cdp.Debugger.PausedEvent): Promise<boolean>;
+
+  initialize(): Promise<void>;
   waitingForDebugger(): boolean;
   supportsCustomBreakpoints(): boolean;
   shouldCheckContentHash(): boolean;

--- a/src/test/node/node-runtime-attaching-attaches-children-of-child-processes.txt
+++ b/src/test/node/node-runtime-attaching-attaches-children-of-child-processes.txt
@@ -1,0 +1,16 @@
+{
+    allThreadsStopped : false
+    description : Paused
+    reason : step
+    threadId : <number>
+}
+foo @ ${fixturesDir}/child.js:1:1
+<anonymous> @ ${fixturesDir}/child.js:1:1
+Module._compile @ internal/modules/cjs/loader.js:778:30 <hidden: blackboxed>
+Module._extensions..js @ internal/modules/cjs/loader.js:789:10 <hidden: blackboxed>
+Module.load @ internal/modules/cjs/loader.js:653:32 <hidden: blackboxed>
+tryModuleLoad @ internal/modules/cjs/loader.js:593:12 <hidden: blackboxed>
+Module._load @ internal/modules/cjs/loader.js:585:3 <hidden: blackboxed>
+Module.runMain @ internal/modules/cjs/loader.js:831:12 <hidden: blackboxed>
+startup @ internal/bootstrap/node.js:283:19 <hidden: blackboxed>
+bootstrapNodeJSCore @ internal/bootstrap/node.js:622:3 <hidden: blackboxed>

--- a/src/test/node/node-runtime-attaching-attaches-to-existing-processes.txt
+++ b/src/test/node/node-runtime-attaching-attaches-to-existing-processes.txt
@@ -1,0 +1,11 @@
+{
+    allThreadsStopped : false
+    description : Paused
+    reason : step
+    threadId : <number>
+}
+setInterval @ ${fixturesDir}/test.js:1:1
+ontimeout @ timers.js:436:11 <hidden: blackboxed>
+tryOnTimeout @ timers.js:300:5 <hidden: blackboxed>
+listOnTimeout @ timers.js:263:5 <hidden: blackboxed>
+processTimers @ timers.js:223:10 <hidden: blackboxed>

--- a/src/test/node/node-runtime.test.ts
+++ b/src/test/node/node-runtime.test.ts
@@ -91,24 +91,44 @@ describe('node runtime', () => {
 
   describe('attaching', () => {
     let child: ChildProcess | undefined;
-    beforeEach(() => {
-      createFileTree(testFixturesDir, {
-        'test.js': ['setInterval(() => { debugger; }, 500)'],
-      });
-    });
 
     afterEach(() => {
       if (child) {
         child.kill();
       }
-    });
+    })
 
     itIntegrates('attaches to existing processes', async ({ r }) => {
+      createFileTree(testFixturesDir, {
+        'test.js': ['setInterval(() => { debugger; }, 500)'],
+      });
+
       child = spawn('node', ['--inspect', join(testFixturesDir, 'test')]);
       await delay(500); // give it a moment to boot
       const handle = await r.attachNode(child.pid);
       await waitForPause(handle);
       handle.assertLog();
+    });
+
+    itIntegrates('attaches children of child processes', async ({ r }) => {
+      createFileTree(testFixturesDir, {
+        'test.js': `
+          const { spawn } = require('child_process');
+          setInterval(() => spawn('node', ['child'], { cwd: __dirname }), 500);
+        `,
+        'child.js': '(function foo() { debugger; })();'
+      });
+
+      child = spawn('node', ['--inspect', join(testFixturesDir, 'test')]);
+      await delay(500); // give it a moment to boot
+      const handle = await r.attachNode(child.pid);
+      handle.load();
+
+      const worker = await r.worker();
+      worker.load();
+
+      await waitForPause(worker);
+      worker.assertLog();
     });
   });
 

--- a/src/test/node/node-runtime.test.ts
+++ b/src/test/node/node-runtime.test.ts
@@ -14,8 +14,9 @@ import { join } from 'path';
 import { expect } from 'chai';
 import { stub } from 'sinon';
 import { TerminalProgramLauncher } from '../../targets/node/terminalProgramLauncher';
-import { spawn } from 'child_process';
+import { spawn, ChildProcess } from 'child_process';
 import Dap from '../../dap/api';
+import { delay } from '../../common/promiseUtil';
 
 describe('node runtime', () => {
   async function waitForPause(p: ITestHandle) {
@@ -86,6 +87,29 @@ describe('node runtime', () => {
     } finally {
       launch.restore();
     }
+  });
+
+  describe('attaching', () => {
+    let child: ChildProcess | undefined;
+    beforeEach(() => {
+      createFileTree(testFixturesDir, {
+        'test.js': ['setInterval(() => { debugger; }, 500)'],
+      });
+    });
+
+    afterEach(() => {
+      if (child) {
+        child.kill();
+      }
+    });
+
+    itIntegrates('attaches to existing processes', async ({ r }) => {
+      child = spawn('node', ['--inspect', join(testFixturesDir, 'test')]);
+      await delay(500); // give it a moment to boot
+      const handle = await r.attachNode(child.pid);
+      await waitForPause(handle);
+      handle.assertLog();
+    });
   });
 
   describe('child processes', () => {

--- a/src/ui/processPicker.ts
+++ b/src/ui/processPicker.ts
@@ -1,0 +1,252 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+'use strict';
+
+import * as nls from 'vscode-nls';
+import * as vscode from 'vscode';
+import { basename } from 'path';
+import { getProcesses } from './processTree';
+import { execSync } from 'child_process';
+import { Contributions } from '../common/contributionUtils';
+import {
+  nodeAttachConfigDefaults,
+  INodeAttachConfiguration,
+  ResolvingNodeAttachConfiguration,
+} from '../configuration';
+import { guessWorkingDirectory } from '../nodeDebugConfigurationProvider';
+import { mapValues } from '../common/objUtils';
+
+const INSPECTOR_PORT_DEFAULT = 9229;
+
+const localize = nls.loadMessageBundle();
+
+interface ProcessItem extends vscode.QuickPickItem {
+  pidOrPort: string; // picker result
+  sortKey: number;
+}
+
+/**
+ * end user action for picking a process and attaching debugger to it
+ */
+export async function attachProcess() {
+  let config: INodeAttachConfiguration = {
+    ...nodeAttachConfigDefaults,
+    name: 'process',
+    processId: `\${command:${Contributions.PickProcessCommand}}`,
+  };
+
+  if (!(await resolveProcessId(config))) {
+    return;
+  }
+
+  const cwd = guessWorkingDirectory(config);
+  const assignWorkspaceFolder = (obj: any) =>
+    mapValues(obj, value => {
+      if (typeof value === 'string') {
+        return value.replace('${workspaceFolder}', cwd);
+      }
+
+      if (value && typeof value === 'object') {
+        return assignWorkspaceFolder(value);
+      }
+
+      return value;
+    });
+
+  config = assignWorkspaceFolder(config);
+  return vscode.debug.startDebugging(undefined, config);
+}
+
+/**
+ * Resolves the requested process ID, and updates the config object
+ * appropriately. Returns true if the configuration was updated, false
+ * if it was cancelled.
+ */
+export async function resolveProcessId(config: ResolvingNodeAttachConfiguration): Promise<boolean> {
+  // we resolve Process Picker early (before VS Code) so that we can probe the process for its protocol
+  let processId = config.processId && config.processId.trim();
+  if (
+    !processId ||
+    processId === '${command:PickProcess}' ||
+    processId === `\${command:${Contributions.PickProcessCommand}}`
+  ) {
+    const result = await pickProcess(true); // ask for pids and ports!
+    if (!result) {
+      return false; // UI dismissed (cancelled)
+    }
+
+    processId = result;
+  }
+
+  const matches = /^(inspector)?([0-9]+)(inspector)?([0-9]+)?$/.exec(processId);
+  if (!matches || matches.length !== 5) {
+    throw new Error(
+      localize(
+        'process.id.error',
+        "Attach to process: '{0}' doesn't look like a process id.",
+        processId,
+      ),
+    );
+  }
+
+  if (matches[2] && matches[3] && matches[4]) {
+    // process id and protocol and port
+    const pid = Number(matches[2]);
+    putPidInDebugMode(pid);
+
+    // debug port
+    config.port = Number(matches[4]);
+    delete config.processId;
+  } else {
+    // protocol and port
+    if (matches[1]) {
+      // debug port
+      config.port = Number(matches[2]);
+      delete config.processId;
+    } else {
+      // process id
+      const pid = Number(matches[2]);
+      putPidInDebugMode(pid);
+
+      // processID is handled, so turn this config into a normal port attach configuration
+      delete config.processId;
+      config.port = INSPECTOR_PORT_DEFAULT;
+    }
+  }
+
+  return true;
+}
+
+/**
+ * Process picker command (for launch config variable)
+ * Returns as a string with these formats:
+ * - "12345": process id
+ * - "inspector12345": port number and inspector protocol
+ * - "legacy12345": port number and legacy protocol
+ * - null: abort launch silently
+ */
+export async function pickProcess(ports: boolean = false): Promise<string | null> {
+  try {
+    const items = await listProcesses();
+    let options: vscode.QuickPickOptions = {
+      placeHolder: localize('pickNodeProcess', 'Pick the node.js process to attach to'),
+      matchOnDescription: true,
+      matchOnDetail: true,
+    };
+    const item = await vscode.window.showQuickPick(items, options);
+    return item ? item.pidOrPort : null;
+  } catch (err) {
+    await vscode.window.showErrorMessage(
+      localize('process.picker.error', 'Process picker failed ({0})', err.message),
+      { modal: true },
+    );
+    return null;
+  }
+}
+
+//---- private
+
+async function listProcesses(): Promise<ProcessItem[]> {
+  const nodeProcessPattern = /^(?:node|iojs)$/i;
+  let seq = 0; // default sort key
+
+  const items = await getProcesses<ProcessItem[]>(({ pid, command, args, date }, acc) => {
+    if (process.platform === 'win32' && command.indexOf('\\??\\') === 0) {
+      // remove leading device specifier
+      command = command.replace('\\??\\', '');
+    }
+
+    const executableName = basename(command, '.exe');
+    const { port } = analyseArguments(args);
+
+    let description: string | void;
+    let pidOrPort: string;
+    if (port) {
+      description = localize(
+        'process.id.port.signal',
+        'process id: {0}, debug port: {1} ({2})',
+        pid,
+        port,
+        'SIGUSR1',
+      );
+      pidOrPort = `${pid}${port}`;
+    } else if (nodeProcessPattern.test(executableName)) {
+      description = localize('process.id.signal', 'process id: {0} ({1})', pid, 'SIGUSR1');
+      pidOrPort = pid.toString();
+    } else {
+      return acc;
+    }
+
+    return [
+      ...acc,
+      {
+        // render data
+        label: executableName,
+        description: args,
+        detail: description,
+        // picker result
+        pidOrPort: pidOrPort,
+        // sort key
+        sortKey: date ? date : seq++,
+      },
+    ];
+  }, []);
+
+  return items.sort((a, b) => b.sortKey - a.sortKey); // sort items by process id, newest first
+}
+
+function putPidInDebugMode(pid: number): void {
+  try {
+    if (process.platform === 'win32') {
+      // regular node has an undocumented API function for forcing another node process into debug mode.
+      // 		(<any>process)._debugProcess(pid);
+      // But since we are running on Electron's node, process._debugProcess doesn't work (for unknown reasons).
+      // So we use a regular node instead:
+      const command = `node -e process._debugProcess(${pid})`;
+      execSync(command);
+    } else {
+      process.kill(pid, 'SIGUSR1');
+    }
+  } catch (e) {
+    throw new Error(
+      localize(
+        'cannot.enable.debug.mode.error',
+        "Attach to process: cannot enable debug mode for process '{0}' ({1}).",
+        pid,
+        e,
+      ),
+    );
+  }
+}
+
+/*
+ * analyse the given command line arguments and extract debug port and protocol from it.
+ */
+export function analyseArguments(args: string) {
+  const DEBUG_FLAGS_PATTERN = /--inspect(-brk)?(=((\[[0-9a-fA-F:]*\]|[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+|[a-zA-Z0-9\.]*):)?(\d+))?/;
+  const DEBUG_PORT_PATTERN = /--inspect-port=(\d+)/;
+
+  let address: string | undefined;
+  let port: number | undefined;
+
+  // match --inspect, --inspect=1234, --inspect-brk, --inspect-brk=1234
+  let matches = DEBUG_FLAGS_PATTERN.exec(args);
+  if (matches && matches.length >= 2) {
+    if (matches.length >= 6 && matches[5]) {
+      address = matches[5];
+    }
+    if (matches.length >= 7 && matches[6]) {
+      port = parseInt(matches[6]);
+    }
+  }
+
+  // a --inspect-port=1234 overrides the port
+  matches = DEBUG_PORT_PATTERN.exec(args);
+  if (matches && matches.length === 3) {
+    port = parseInt(matches[2]);
+  }
+
+  return { address, port };
+}

--- a/src/ui/processTree.ts
+++ b/src/ui/processTree.ts
@@ -1,0 +1,206 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+'use strict';
+
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
+import { join } from 'path';
+
+export class ProcessTreeNode {
+  children?: ProcessTreeNode[];
+
+  constructor(
+    public pid: number,
+    public ppid: number,
+    public command: string,
+    public args: string,
+  ) {}
+}
+
+export async function getProcessTree(rootPid: number): Promise<ProcessTreeNode | undefined> {
+  const map = new Map<number, ProcessTreeNode>();
+
+  map.set(0, new ProcessTreeNode(0, 0, '???', ''));
+
+  try {
+    await getProcesses(({ pid, ppid, command, args }) => {
+      if (pid !== ppid) {
+        map.set(pid, new ProcessTreeNode(pid, ppid, command, args));
+      }
+      return map;
+    }, null);
+  } catch (err) {
+    return undefined;
+  }
+
+  const values = map.values();
+  for (const p of values) {
+    const parent = map.get(p.ppid);
+    if (parent && parent !== p) {
+      if (!parent.children) {
+        parent.children = [];
+      }
+      parent.children.push(p);
+    }
+  }
+
+  if (!isNaN(rootPid) && rootPid > 0) {
+    return map.get(rootPid);
+  }
+  return map.get(0);
+}
+
+export interface IProcess {
+  pid: number;
+  ppid: number;
+  command: string;
+  args: string;
+  date?: number;
+}
+
+export function getProcesses<T>(
+  one: (proces: IProcess, accumulator: T) => T,
+  accumulator: T,
+): Promise<T> {
+  // returns a function that aggregates chunks of data until one or more complete lines are received and passes them to a callback.
+  function lines(callback: (a: string) => void) {
+    let unfinished = ''; // unfinished last line of chunk
+    return (data: string | Buffer) => {
+      const lines = data.toString().split(/\r?\n/);
+      const finishedLines = lines.slice(0, lines.length - 1);
+      finishedLines[0] = unfinished + finishedLines[0]; // complete previous unfinished line
+      unfinished = lines[lines.length - 1]; // remember unfinished last line of this chunk for next round
+      for (const s of finishedLines) {
+        callback(s);
+      }
+    };
+  }
+
+  return new Promise<T>((resolve, reject) => {
+    let proc: ChildProcessWithoutNullStreams;
+
+    if (process.platform === 'win32') {
+      // attributes columns are in alphabetic order!
+      const CMD_PAT = /^(.*)\s+([0-9]+)\.[0-9]+[+-][0-9]+\s+([0-9]+)\s+([0-9]+)$/;
+
+      const wmic = join(process.env['WINDIR'] || 'C:\\Windows', 'System32', 'wbem', 'WMIC.exe');
+      proc = spawn(wmic, ['process', 'get', 'CommandLine,CreationDate,ParentProcessId,ProcessId']);
+      proc.stdout.setEncoding('utf8');
+      proc.stdout.on(
+        'data',
+        lines(line => {
+          let matches = CMD_PAT.exec(line.trim());
+          if (matches && matches.length === 5) {
+            const pid = Number(matches[4]);
+            const ppid = Number(matches[3]);
+            const date = Number(matches[2]);
+            let args = matches[1].trim();
+            if (!isNaN(pid) && !isNaN(ppid) && args) {
+              let command = args;
+              if (args[0] === '"') {
+                const end = args.indexOf('"', 1);
+                if (end > 0) {
+                  command = args.substr(1, end - 1);
+                  args = args.substr(end + 2);
+                }
+              } else {
+                const end = args.indexOf(' ');
+                if (end > 0) {
+                  command = args.substr(0, end);
+                  args = args.substr(end + 1);
+                } else {
+                  args = '';
+                }
+              }
+              accumulator = one({ pid, ppid, command, args, date }, accumulator);
+            }
+          }
+        }),
+      );
+    } else if (process.platform === 'darwin') {
+      // OS X
+
+      proc = spawn('/bin/ps', ['-x', '-o', `pid,ppid,comm=${'a'.repeat(256)},command`]);
+      proc.stdout.setEncoding('utf8');
+      proc.stdout.on(
+        'data',
+        lines(line => {
+          const pid = Number(line.substr(0, 5));
+          const ppid = Number(line.substr(6, 5));
+          const command = line.substr(12, 256).trim();
+          const args = line.substr(269 + command.length);
+
+          if (!isNaN(pid) && !isNaN(ppid)) {
+            accumulator = one({ pid, ppid, command, args }, accumulator);
+          }
+        }),
+      );
+    } else {
+      // linux
+
+      proc = spawn('/bin/ps', ['-ax', '-o', 'pid,ppid,comm:20,command']);
+      proc.stdout.setEncoding('utf8');
+      proc.stdout.on(
+        'data',
+        lines(line => {
+          const pid = Number(line.substr(0, 5));
+          const ppid = Number(line.substr(6, 5));
+          let command = line.substr(12, 20).trim();
+          let args = line.substr(33);
+
+          let pos = args.indexOf(command);
+          if (pos >= 0) {
+            pos = pos + command.length;
+            while (pos < args.length) {
+              if (args[pos] === ' ') {
+                break;
+              }
+              pos++;
+            }
+            command = args.substr(0, pos);
+            args = args.substr(pos + 1);
+          }
+
+          if (!isNaN(pid) && !isNaN(ppid)) {
+            accumulator = one({ pid, ppid, command, args }, accumulator);
+          }
+        }),
+      );
+    }
+
+    proc.on('error', err => {
+      reject(err);
+    });
+
+    proc.stderr.setEncoding('utf8');
+    proc.stderr.on('data', data => {
+      reject(new Error(data.toString()));
+    });
+
+    proc.on('close', (code, signal) => {
+      if (code === 0) {
+        resolve(accumulator);
+      } else if (code > 0) {
+        reject(new Error(`process terminated with exit code: ${code}`));
+      }
+      if (signal) {
+        reject(new Error(`process terminated with signal: ${signal}`));
+      }
+    });
+
+    proc.on('exit', (code, signal) => {
+      if (typeof code === 'number') {
+        if (code === 0) {
+          //resolve();
+        } else if (code > 0) {
+          reject(new Error(`process terminated with exit code: ${code}`));
+        }
+      }
+      if (signal) {
+        reject(new Error(`process terminated with signal: ${signal}`));
+      }
+    });
+  });
+}

--- a/src/ui/sessionManager.ts
+++ b/src/ui/sessionManager.ts
@@ -15,6 +15,7 @@ import { SubprocessProgramLauncher } from '../targets/node/subprocessProgramLaun
 import { DebugAdapter } from '../adapter/debugAdapter';
 import { Contributions } from '../common/contributionUtils';
 import { TerminalProgramLauncher } from '../targets/node/terminalProgramLauncher';
+import { NodeAttacher } from '../targets/node/nodeAttacher';
 
 export class Session implements Disposable {
   public readonly debugSession: vscode.DebugSession;
@@ -41,6 +42,7 @@ export class Session implements Disposable {
   createBinder(context: vscode.ExtensionContext, delegate: BinderDelegate) {
     const launchers = [
       new NodeLauncher([new SubprocessProgramLauncher(), new TerminalProgramLauncher()]),
+      new NodeAttacher(),
       new BrowserLauncher(context.storagePath || context.extensionPath),
       new BrowserAttacher(),
     ];


### PR DESCRIPTION
This doesn't totally work yet, but I figured this set of changes is big enough.
This implements attaching to an existing/running Node process. It refactors
some of the logic from `NodeLauncher` into an abstract `NodeLauncherBase`
class. We bring in the existing process picker and process tree logic, and
then to attach to a process we run the existing watchdog script (with a few
tweaks) against the target. I'm fairly happy with how this structure ended
up looking. Existing tests for the node runtime still pass.

The code in this PR successfully attaches to a running process, handles
breakpoint state and shows the callstack, but some things are still missing.
I'll add those in a separate PR, or this one if they end up being
one-line changes (I have a feeling there's just a few more .enable()
calls I need to make).

For a separate PR is setting environment variables in the attached process
so that child processes are tracked just like the programs we launch ourselves.