### PR TITLE
fix: pause CDP events until the adapter is fully connected to avoid races

### DIFF
--- a/scripts/generate-cdp-api.js
+++ b/scripts/generate-cdp-api.js
@@ -147,9 +147,21 @@ async function generate() {
     result.push(`  }`);
   }
 
+  function appendPauseResume() {
+    result.push(`    /**`);
+    result.push(`     * Pauses events being sent through the aPI.`);
+    result.push(`     */`);
+    result.push(`    pause(): void;`);
+    result.push(`    /**`);
+    result.push(`     * Resumes previously-paused events`);
+    result.push(`     */`);
+    result.push(`    resume(): void;`);
+  }
+
   interfaceSeparator();
   appendText('Protocol API.', '  ');
   result.push(`  export interface Api {`);
+  appendPauseResume();
   domains.forEach(d => {
     result.push(`    ${d.domain}: ${d.domain}Api;`)
   });

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -172,7 +172,7 @@ export class Binder implements Disposable {
       });
     }
 
-    cdp.resume();
+    await target.afterBind();
   }
 
   async detach(target: Target) {

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -171,6 +171,8 @@ export class Binder implements Disposable {
         return {};
       });
     }
+
+    cdp.resume();
   }
 
   async detach(target: Target) {

--- a/src/cdp/connection.ts
+++ b/src/cdp/connection.ts
@@ -74,7 +74,6 @@ export default class Connection {
     if (sessionId)
       message.sessionId = sessionId;
     const messageString = JSON.stringify(message);
-    // console.log(`SEND ► ${messageString}`);
     if (this._logPath)
       require('fs').appendFileSync(this._logPath, `SEND ► [${this._logPrefix}] ${messageString}\n`);
     this._transport.send(messageString);
@@ -271,7 +270,6 @@ class CDPSession {
         callback.resolve(object.result!);
       }
     } else {
-      // console.log(`◀ RECV EV ${JSON.stringify(object)}`);
       const listeners = this._listeners.get(object.method!);
       for (const listener of listeners || [])
         listener(object.params);

--- a/src/targets/browser/browserTargets.ts
+++ b/src/targets/browser/browserTargets.ts
@@ -172,6 +172,8 @@ export class BrowserTarget implements Target {
 
   constructor(targetManager: BrowserTargetManager, targetInfo: Cdp.Target.TargetInfo, cdp: Cdp.Api, parentTarget: BrowserTarget | undefined, waitingForDebugger: boolean, ondispose: (t: BrowserTarget) => void) {
     this._cdp = cdp;
+    cdp.pause();
+
     this._manager = targetManager;
     this.parentTarget = parentTarget;
     this._waitingForDebugger = waitingForDebugger;
@@ -202,6 +204,11 @@ export class BrowserTarget implements Target {
 
   type(): string {
     return this._targetInfo.type;
+  }
+
+  afterBind() {
+    this._cdp.resume();
+    return Promise.resolve();
   }
 
   parent(): Target | undefined {

--- a/src/targets/node/nodeAttacher.ts
+++ b/src/targets/node/nodeAttacher.ts
@@ -40,6 +40,11 @@ export class NodeAttacher extends NodeLauncherBase<INodeAttachConfiguration> {
       dynamicAttach: true,
     });
 
-    this.program = new SubprocessProgram(wd);
+    const program = (this.program = new SubprocessProgram(wd));
+    this.program.stopped.then(result => {
+      if (program === this.program) {
+        this.onProgramTerminated(result);
+      }
+    });
   }
 }

--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -135,10 +135,10 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
    */
   public async terminate(): Promise<void> {
     if (this.program) {
-      await this.program.stop(); // will stop the server when it's done, in onProgramTerminated
-    } else {
-      this._stopServer();
+      this.program.stop();
     }
+
+    this.onProgramTerminated({ code: 0, killed: true });
   }
 
   /**

--- a/src/targets/node/nodeTarget.ts
+++ b/src/targets/node/nodeTarget.ts
@@ -37,6 +37,7 @@ export class NodeTarget implements Target {
   ) {
     this.connection = connection;
     this._cdp = cdp;
+    cdp.pause();
     this._targetId = targetInfo.targetId;
     this._scriptName = targetInfo.title;
     this._waitingForDebugger = targetInfo.type === 'waitingForDebugger';
@@ -161,6 +162,10 @@ export class NodeTarget implements Target {
     return this._cdp;
   }
 
+  public async afterBind() {
+    this._cdp.resume();
+  }
+
   canDetach(): boolean {
     return this._attached;
   }
@@ -188,9 +193,15 @@ export class NodeTarget implements Target {
   }
 
   stop() {
-    try {
-      process.kill(+this._targetId);
-    } catch (e) {}
+    const processId = Number(this._targetId);
+    if (processId > 0) {
+      try {
+        process.kill(+this._targetId);
+      } catch (e) {
+        // ignored
+      }
+    }
+
     this.connection.close();
   }
 }

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -29,6 +29,11 @@ export interface Target {
   canDetach(): boolean;
   detach(): Promise<void>;
   targetOrigin(): any;
+  /**
+   * Lifecycle callback invoked after attaching and the target's events are
+   * wired into the debug adapter.
+   */
+  afterBind(): Promise<void>;
 
   waitingForDebugger(): boolean;
   supportsCustomBreakpoints(): boolean;

--- a/src/test/node/node-runtime-attaching-attaches-to-existing-processes.txt
+++ b/src/test/node/node-runtime-attaching-attaches-to-existing-processes.txt
@@ -1,0 +1,11 @@
+{
+    allThreadsStopped : false
+    description : Paused
+    reason : step
+    threadId : <number>
+}
+setInterval @ ${fixturesDir}/test.js:1:1
+ontimeout @ timers.js:436:11 <hidden: blackboxed>
+tryOnTimeout @ timers.js:300:5 <hidden: blackboxed>
+listOnTimeout @ timers.js:263:5 <hidden: blackboxed>
+processTimers @ timers.js:223:10 <hidden: blackboxed>

--- a/src/test/node/node-runtime.test.ts
+++ b/src/test/node/node-runtime.test.ts
@@ -14,8 +14,9 @@ import { join } from 'path';
 import { expect } from 'chai';
 import { stub } from 'sinon';
 import { TerminalProgramLauncher } from '../../targets/node/terminalProgramLauncher';
-import { spawn } from 'child_process';
+import { spawn, ChildProcess } from 'child_process';
 import Dap from '../../dap/api';
+import { delay } from '../../common/promiseUtil';
 
 describe('node runtime', () => {
   async function waitForPause(p: ITestHandle) {
@@ -86,6 +87,29 @@ describe('node runtime', () => {
     } finally {
       launch.restore();
     }
+  });
+
+  describe('attaching', () => {
+    let child: ChildProcess | undefined;
+    beforeEach(() => {
+      createFileTree(testFixturesDir, {
+        'test.js': ['setInterval(() => { debugger; }, 500)'],
+      });
+    });
+
+    afterEach(() => {
+      if (child) {
+        child.kill();
+      }
+    });
+
+    itIntegrates('attaches to existing processes', async ({ r }) => {
+      child = spawn('node', ['--inspect', join(testFixturesDir, 'test')]);
+      await delay(500); // give it a moment to boot
+      const handle = await r.attachNode(child.pid);
+      await waitForPause(handle);
+      handle.assertLog();
+    });
   });
 
   describe('child processes', () => {


### PR DESCRIPTION
Stacked on #47. The issue was that when we attach to a running Node process, it already has all the scripts and threads loaded in memory, and it was sending this effectively instantly--before we finished setting up our listeners on the CDP connection.

My initial approach was to move the call to `await this._cdp.Debugger.enable({});` to the `afterBind()` hook, but I realize it was probably just luck that made it work with Node launches initially, so instead I implementing a pause/resume mechanic in the CDP connection, allowing us to pause events sent down the CDP until after we're listening and ready to start receiving them.