### PR TITLE
fix: don't send the initialized event until after we respond to initi…

### DIFF
--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -61,8 +61,9 @@ export class DebugAdapter {
   async _onInitialize(params: Dap.InitializeParams): Promise<Dap.InitializeResult | Dap.Error> {
     console.assert(params.linesStartAt1);
     console.assert(params.columnsStartAt1);
-    this.dap.initialized({});
-    return DebugAdapter.capabilities();
+    const capabilities = DebugAdapter.capabilities();
+    setTimeout(() => this.dap.initialized({}), 0);
+    return capabilities;
   }
 
   static capabilities(): Dap.Capabilities {

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -49,8 +49,11 @@ export class Binder implements Disposable {
 
     this._dap.then(dap => {
       dap.on('initialize', async () => {
-        dap.initialized({});
-        return DebugAdapter.capabilities();
+        const capabilities = DebugAdapter.capabilities();
+        setTimeout(() => {
+          dap.initialized({});
+        }, 0);
+        return capabilities;
       });
       dap.on('setExceptionBreakpoints', async () => ({}));
       dap.on('setBreakpoints', async params => {


### PR DESCRIPTION
…alize.

The DAP specifically states that the adapter should not send any events or messages before it responds to the initialize request. VS Code will handle things just fine if it does, but VS treats this as a fatal error and closes the session.