### PR TITLE
fix: use default sourceMapOverrides if not in launch config.

### DIFF
--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -319,7 +319,7 @@ export type AnyLaunchConfiguration = AnyChromeConfiguration | AnyNodeConfigurati
 export type ResolvingNodeConfiguration = IMandatedConfiguration & Partial<AnyNodeConfiguration>;
 export type ResolvingChromeConfiguration = IMandatedConfiguration & Partial<AnyChromeConfiguration>;
 
-const baseDefaults: IBaseConfiguration = {
+export const baseDefaults: IBaseConfiguration = {
   type: '',
   name: '',
   request: '',
@@ -335,6 +335,7 @@ const baseDefaults: IBaseConfiguration = {
   skipFiles: [],
   smartStep: true,
   sourceMaps: true,
+  // keep in sync with sourceMapPathOverrides in package.json
   sourceMapPathOverrides: {
     'webpack:///*': '*',
     'webpack:///./~/*': '${workspaceRoot}/node_modules/*',

--- a/src/targets/sourcePathResolver.ts
+++ b/src/targets/sourcePathResolver.ts
@@ -11,6 +11,7 @@ import {
 } from '../common/pathUtils';
 import * as path from 'path';
 import { isFileUrl } from '../common/urlUtils';
+import { baseDefaults } from '../configuration';
 
 export interface ISourcePathResolverOptions {
   sourceMapOverrides: { [key: string]: string };
@@ -73,7 +74,7 @@ export abstract class SourcePathResolverBase<T extends ISourcePathResolverOption
    * as a filesystem path, not a URI.
    */
   protected applyPathOverrides(sourcePath: string) {
-    const { sourceMapOverrides } = this.options;
+    const { sourceMapOverrides = baseDefaults.sourceMapPathOverrides } = this.options;
     const forwardSlashSourcePath = sourcePath.replace(/\\/g, '/');
 
     // Sort the overrides by length, large to small


### PR DESCRIPTION
Also pulling the default sourceMapPathOverrides from v1/v2