### PR TITLE
feat: attach to child processes of attached children, support stopOnEntry

### DIFF
--- a/demos/node/child.js
+++ b/demos/node/child.js
@@ -1,0 +1,4 @@
+setTimeout(
+  () => console.log(`Hello from child ${process.argv[2]}! Options:`, process.env.NODE_OPTIONS),
+  2000,
+);

--- a/demos/node/parent.js
+++ b/demos/node/parent.js
@@ -1,0 +1,8 @@
+const { spawn } = require('child_process');
+
+let counter = 0;
+setInterval(() => {
+  const id = counter++;
+  console.log('Spawning child', id);
+  spawn('node', ['child', id], { cwd: __dirname, stdio: 'inherit' });
+}, 5000);

--- a/package.json
+++ b/package.json
@@ -893,7 +893,7 @@
                   "stopOnEntry": {
                     "type": "boolean",
                     "description": "%node.stopOnEntry.description%",
-                    "default": true
+                    "default": false
                   },
                   "console": {
                     "type": "string",

--- a/package.nls.json
+++ b/package.nls.json
@@ -33,6 +33,8 @@
   "node.address.description": "TCP/IP address of process to be debugged. Default is 'localhost'.",
   "node.attach.config.name": "Attach",
   "node.attach.processId.description": "ID of process to attach to.",
+  "node.attach.attachSpawnedProcesses.description": "Whether to set environment variables in the attached process to track spawned children.",
+  "node.attach.attachExistingChildren.description": "Whether to attempt to attach to already-spawned child processes.",
   "node.console.title": "Node Debug Console",
   "node.disableOptimisticBPs.description": "Don't set breakpoints in any file until a sourcemap has been loaded for that file.",
   "node.label": "Node.js",

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -49,12 +49,18 @@ export class ExecutionContext {
 export type Script = { url: string, scriptId: string, hash: string, source: Source };
 
 export interface ThreadDelegate {
+  /**
+   * Handler triggered on a breakpoint. If this returns true, the UI will be
+   * continued and no breakpoint will be shown to the user.
+   */
+  onPaused(details: Cdp.Debugger.PausedEvent): Promise<boolean>;
   supportsCustomBreakpoints(): boolean;
   shouldCheckContentHash(): boolean;
   defaultScriptOffset(): InlineScriptOffset | undefined;
   scriptUrlToUrl(url: string): string;
   executionContextName(description: Cdp.Runtime.ExecutionContextDescription): string;
   blackboxPattern(): string | undefined;
+  initialize(): Promise<void>
 }
 
 export type ScriptWithSourceMapHandler = (script: Script, sources: Source[]) => Promise<void>;
@@ -397,6 +403,10 @@ export class Thread implements VariableStoreDelegate {
         return;
       }
 
+      if (await this._delegate.onPaused(event)) {
+        return;
+      }
+
       this._pausedDetails = this._createPausedDetails(event);
       this._pausedDetails[kPausedEventSymbol] = event;
       this._pausedVariables = new VariableStore(this._cdp, this);
@@ -404,10 +414,10 @@ export class Thread implements VariableStoreDelegate {
       this._onThreadPaused();
     });
     this._cdp.Debugger.on('resumed', () => this._onResumed());
-
     this._cdp.Debugger.on('scriptParsed', event => this._onScriptParsed(event));
 
     this._ensureDebuggerEnabledAndRefreshDebuggerId();
+    this._delegate.initialize();
     this._cdp.Debugger.setAsyncCallStackDepth({ maxDepth: 32 });
     const blackboxPattern = this._delegate.blackboxPattern();
     if (blackboxPattern) {

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -181,3 +181,23 @@ export function platformPathToPreferredCase(p: string | undefined): string | und
   if (p && process.platform === 'win32' && p[1] === ':') return p[0].toUpperCase() + p.substring(1);
   return p;
 }
+
+const loopbacks: ReadonlySet<string> = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '0:0:0:0:0:0:0:1',
+]);
+
+/**
+ * Returns whether the given URL is a loopback address.
+ */
+
+export const isLoopback = (address: string) => {
+  try {
+    const url = new URL(address);
+    return loopbacks.has(url.hostname);
+  } catch {
+    return loopbacks.has(address);
+  }
+};

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -248,6 +248,17 @@ export interface INodeAttachConfiguration extends INodeBaseConfiguration {
    * ID of process to attach to.
    */
   processId?: string;
+
+  /**
+   * Whether to set environment variables in the attached process to track
+   * spawned children.
+   */
+  attachSpawnedProcesses: boolean;
+
+  /**
+   * Whether to attempt to attach to already-spawned child processes.
+   */
+  attachExistingChildren: boolean;
 }
 
 export interface IChromeLaunchConfiguration extends IChromeBaseConfiguration {
@@ -350,7 +361,7 @@ export const nodeLaunchConfigDefaults: INodeLaunchConfiguration = {
   ...nodeBaseDefaults,
   request: 'launch',
   program: '',
-  stopOnEntry: true,
+  stopOnEntry: false,
   console: 'internalConsole',
   args: [],
   runtimeExecutable: 'node',
@@ -386,6 +397,8 @@ export const chromeLaunchConfigDefaults: IChromeLaunchConfiguration = {
 
 export const nodeAttachConfigDefaults: INodeAttachConfiguration = {
   ...nodeBaseDefaults,
+  attachSpawnedProcesses: true,
+  attachExistingChildren: true,
   request: 'attach',
   processId: '',
 };

--- a/src/targets/browser/browserTargets.ts
+++ b/src/targets/browser/browserTargets.ts
@@ -211,6 +211,14 @@ export class BrowserTarget implements Target {
     return Promise.resolve();
   }
 
+  initialize() {
+    return Promise.resolve();
+  }
+
+  onPaused() {
+    return Promise.resolve(false);
+  }
+
   parent(): Target | undefined {
     if (this.parentTarget && !jsTypes.has(this.parentTarget.type()))
       return this.parentTarget.parentTarget;

--- a/src/targets/node/bootloader.ts
+++ b/src/targets/node/bootloader.ts
@@ -5,6 +5,7 @@ import * as inspector from 'inspector';
 import { writeFileSync } from 'fs';
 import { spawnWatchdog } from './watchdogSpawn';
 import { IProcessTelemetry } from './nodeLauncherBase';
+import { LeaseFile } from './lease-file';
 
 function debugLog() {
   // require('fs').appendFileSync(require('path').join(require('os').homedir(), 'bootloader.txt'), `BOOTLOADER [${process.pid}] ${text}\n`);
@@ -13,6 +14,12 @@ function debugLog() {
 (function() {
   debugLog();
   if (!process.env.NODE_INSPECTOR_IPC) return;
+
+  const leaseFile = process.env.NODE_INSPECTOR_REQUIRE_LEASE;
+  if (leaseFile && !LeaseFile.isValid(leaseFile)) {
+    process.env.NODE_INSPECTOR_IPC = undefined; // save work for any children
+    return;
+  }
 
   // Electron support
   // Do not enable for Electron and other hybrid environments.

--- a/src/targets/node/lease-file.ts
+++ b/src/targets/node/lease-file.ts
@@ -1,0 +1,66 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as path from 'path';
+import { tmpdir } from 'os';
+import { randomBytes } from 'crypto';
+import { Disposable } from '../../common/events';
+import { unlinkSync, existsSync, readFileSync, writeFileSync } from 'fs';
+
+/**
+ * File that stores a lease on the filesystem. Can be validated to ensure
+ * that the file is still 'held' by someone.
+ */
+export class LeaseFile implements Disposable {
+  private static readonly updateInterval = 1000;
+  private static readonly recencyDeadline = 2000;
+
+  /**
+   * Path of the callback file.
+   */
+  public readonly path = path.join(
+    tmpdir(),
+    `node-debug-callback-${randomBytes(8).toString('hex')}`,
+  );
+
+  /**
+   * Update timer.
+   */
+  private updateInterval: NodeJS.Timer;
+
+  constructor() {
+    this.touch();
+    this.updateInterval = setInterval(() => this.touch(), LeaseFile.updateInterval);
+  }
+
+  /**
+   * Returns whether the given file path points to a valid lease.
+   */
+  public static isValid(file: string) {
+    try {
+      return Number(readFileSync(file, 'utf-8')) > Date.now() - LeaseFile.recencyDeadline;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Updates the leased file.
+   */
+  public touch() {
+    writeFileSync(this.path, String(Date.now()));
+  }
+
+  /**
+   * Diposes of the callback file.
+   */
+  public dispose() {
+    clearInterval(this.updateInterval);
+    try {
+      unlinkSync(this.path);
+    } catch {
+      // ignored
+    }
+  }
+}

--- a/src/targets/node/nodeAttacher.ts
+++ b/src/targets/node/nodeAttacher.ts
@@ -8,8 +8,11 @@ import { getWSEndpoint } from '../browser/launcher';
 import { spawnWatchdog } from './watchdogSpawn';
 import { NodeLauncherBase, IRunData } from './nodeLauncherBase';
 import { findInPath } from '../../common/pathUtils';
-import { Socket } from 'net';
 import { SubprocessProgram } from './program';
+import Cdp from '../../cdp/api';
+import { isLoopback } from '../../common/urlUtils';
+import { INodeTargetLifecycleHooks } from './nodeTarget';
+import { LeaseFile } from './lease-file';
 
 /**
  * Attaches to ongoing Node processes. This works pretty similar to the
@@ -19,6 +22,13 @@ import { SubprocessProgram } from './program';
  * child processes operate just like those we boot with the NodeLauncher.
  */
 export class NodeAttacher extends NodeLauncherBase<INodeAttachConfiguration> {
+  /**
+   * Tracker for whether we're waiting to break and instrument into the main
+   * process. This is used to avoid instrumenting unecessarily into subsequent
+   * children.
+   */
+  private capturedBreaker = false;
+
   /**
    * @inheritdoc
    */
@@ -46,5 +56,100 @@ export class NodeAttacher extends NodeLauncherBase<INodeAttachConfiguration> {
         this.onProgramTerminated(result);
       }
     });
+
+    this.capturedBreaker = false;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected createLifecycle(
+    cdp: Cdp.Api,
+    run: IRunData<INodeAttachConfiguration>,
+  ): INodeTargetLifecycleHooks {
+    if (this.capturedBreaker) {
+      return {};
+    }
+
+    // We use a lease file to indicate to the process that the debugger is
+    // still running. This is needed because once we attach, we set the
+    // NODE_OPTIONS for the process, forever. We can try to unset this on
+    // close, but this isn't reliable as it's always possible
+    const leaseFile = new LeaseFile();
+
+    let hitFirstBreakpoint = false;
+    this.capturedBreaker = true;
+
+    return {
+      initialized: async () => {
+        await cdp.Debugger.pause({});
+      },
+      paused: async (_target, ev) => {
+        if (hitFirstBreakpoint) {
+          return false;
+        }
+
+        hitFirstBreakpoint = true;
+        await Promise.all([
+          this.gatherTelemetry(cdp),
+          this.setEnvironmentVariables(cdp, run, leaseFile.path),
+        ]);
+        await cdp.Debugger.resume({});
+
+        return true;
+      },
+      close: async () => {
+        leaseFile.dispose();
+      },
+    };
+  }
+
+  private async setEnvironmentVariables(
+    cdp: Cdp.Api,
+    run: IRunData<INodeAttachConfiguration>,
+    leasePath: string,
+  ) {
+    if (!run.params.attachSpawnedProcesses) {
+      return;
+    }
+
+    if (!isLoopback(run.params.address)) {
+      // todo: logger.log("Cannot attach to children of remote process")
+      return;
+    }
+
+    const vars = this.resolveEnvironment(run).merge({
+      NODE_INSPECTOR_PPID: '0',
+      NODE_INSPECTOR_REQUIRE_LEASE: leasePath,
+    });
+
+    const result = await cdp.Runtime.evaluate({
+      contextId: 1,
+      returnByValue: true,
+      expression: `Object.assign(process.env, ${JSON.stringify(vars.defined())})`,
+    });
+
+    if (!result || result.exceptionDetails) {
+      // todo: log error assigning vars
+    }
+  }
+
+  private async gatherTelemetry(cdp: Cdp.Api) {
+    const telemetry = await cdp.Runtime.evaluate({
+      contextId: 1,
+      returnByValue: true,
+      expression: `({ processId: process.pid, nodeVersion: process.version, architecture: process.arch })`,
+    });
+
+    if (!this.program) {
+      return; // shut down
+    }
+
+    if (!telemetry || telemetry.exceptionDetails) {
+      // todo: log error getting telemetry
+      return;
+    }
+
+    this.program.gotTelemetery(telemetry.result.value);
   }
 }

--- a/src/targets/node/nodeLauncher.ts
+++ b/src/targets/node/nodeLauncher.ts
@@ -8,6 +8,10 @@ import { CallbackFile } from './callback-file';
 import { RestartPolicyFactory, IRestartPolicy } from './restartPolicy';
 import { delay } from '../../common/promiseUtil';
 import { NodeLauncherBase, IProcessTelemetry, IRunData } from './nodeLauncherBase';
+import { NodeTarget, INodeTargetLifecycleHooks } from './nodeTarget';
+import { absolutePathToFileUrl } from '../../common/urlUtils';
+import { resolve } from 'path';
+import Cdp from '../../cdp/api';
 
 export class NodeLauncher extends NodeLauncherBase<INodeLaunchConfiguration> {
   constructor(
@@ -91,5 +95,38 @@ export class NodeLauncher extends NodeLauncherBase<INodeLaunchConfiguration> {
     };
 
     doLaunch(this.restarters.create(runData.params));
+  }
+
+  /**
+   * @inheritdoc
+   */
+  protected createLifecycle(
+    cdp: Cdp.Api,
+    run: IRunData<INodeLaunchConfiguration>,
+    { targetId }: Cdp.Target.TargetInfo,
+  ): INodeTargetLifecycleHooks {
+    return {
+      initialized: async () => {
+        if (run.params.stopOnEntry) {
+          const params = {
+            url: absolutePathToFileUrl(resolve(run.params.cwd, run.params.program)),
+            lineNumber: 0,
+            columnNumber: 0,
+          };
+
+          await cdp.Debugger.setBreakpointByUrl(params);
+        }
+      },
+      close: () => {
+        const processId = Number(targetId);
+        if (processId > 0) {
+          try {
+            process.kill(processId);
+          } catch (e) {
+            // ignored
+          }
+        }
+      },
+    };
   }
 }

--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -18,7 +18,7 @@ import {
 } from '../../targets/targets';
 import { AnyLaunchConfiguration, AnyNodeConfiguration } from '../../configuration';
 import { EnvironmentVars } from '../../common/environmentVars';
-import { NodeTarget } from './nodeTarget';
+import { INodeTargetLifecycleHooks, NodeTarget } from './nodeTarget';
 import { NodeSourcePathResolver } from './nodeSourcePathResolver';
 import { IProgram } from './program';
 import { ProtocolError, cannotLoadEnvironmentVars } from '../../dap/errors';
@@ -236,6 +236,13 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
     });
   }
 
+  /**
+   * Logic run when a thread is created.
+   */
+  protected createLifecycle(_cdp: Cdp.Api, _run: IRunData<T>, _target: Cdp.Target.TargetInfo): INodeTargetLifecycleHooks {
+    return {};
+  }
+
   protected _startServer() {
     const pipePrefix = process.platform === 'win32' ? '\\\\.\\pipe\\' : os.tmpdir();
     const pipe = path.join(pipePrefix, `node-cdp.${process.pid}-${++counter}.sock`);
@@ -274,6 +281,7 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
       cdp,
       targetInfo,
       this.run.params,
+      this.createLifecycle(cdp, this.run, targetInfo),
     );
 
     target.setParent(targetInfo.openerId ? this.targets.get(targetInfo.openerId) : undefined);

--- a/src/targets/node/nodeTarget.ts
+++ b/src/targets/node/nodeTarget.ts
@@ -10,6 +10,25 @@ import { EventEmitter } from '../../common/events';
 import { absolutePathToFileUrl } from '../../common/urlUtils';
 import { basename } from 'path';
 
+export interface INodeTargetLifecycleHooks {
+  /**
+   * Invoked when the adapter thread is first initialized.
+   */
+
+  initialized?(target: NodeTarget): Promise<void>;
+
+  /**
+   * Invoked when the thread is paused. Return true if the pause event
+   * is handled internally and should not be returned to the UI.
+   */
+  paused?(target: NodeTarget, notification: Cdp.Debugger.PausedEvent): Promise<boolean>;
+
+  /**
+   * Invoked when the target is stopped.
+   */
+  close?(target: NodeTarget): void;
+}
+
 export class NodeTarget implements Target {
   private _cdp: Cdp.Api;
   private _parent: NodeTarget | undefined;
@@ -33,6 +52,7 @@ export class NodeTarget implements Target {
     cdp: Cdp.Api,
     targetInfo: Cdp.Target.TargetInfo,
     args: AnyNodeConfiguration,
+    private readonly lifecycle: INodeTargetLifecycleHooks = {},
   ) {
     this.connection = connection;
     this._cdp = cdp;
@@ -76,6 +96,16 @@ export class NodeTarget implements Target {
 
   children(): Target[] {
     return Array.from(this._children.values());
+  }
+
+  public async initialize() {
+    if (this.lifecycle.initialized) {
+      this.lifecycle.initialized(this);
+    }
+  }
+
+  public async onPaused(event: Cdp.Debugger.PausedEvent) {
+    return !!this.lifecycle.paused && (await this.lifecycle.paused(this, event));
   }
 
   waitingForDebugger(): boolean {
@@ -192,16 +222,13 @@ export class NodeTarget implements Target {
   }
 
   stop() {
-    const processId = Number(this._targetId);
-    if (processId > 0) {
-      try {
-        process.kill(+this._targetId);
-      } catch (e) {
-        // ignored
+    try {
+      if (this.lifecycle.close) {
+        this.lifecycle.close(this);
       }
+    } finally {
+      this.connection.close();
     }
-
-    this.connection.close();
   }
 }
 

--- a/src/targets/node/program.ts
+++ b/src/targets/node/program.ts
@@ -28,7 +28,7 @@ export class SubprocessProgram implements IProgram {
   public readonly stopped: Promise<IStopMetadata>;
   private killed = false;
 
-  constructor(private child: ChildProcess) {
+  constructor(private readonly child: ChildProcess) {
     this.stopped = new Promise((resolve, reject) => {
       child.once('exit', code => resolve({ killed: this.killed, code: code || 0 }));
       child.once('error', error => reject({ killed: this.killed, code: 1, error }));

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -35,6 +35,13 @@ export interface Target {
    */
   afterBind(): Promise<void>;
 
+  /**
+   * Handler triggered on a breakpoint. If this returns true, the UI will be
+   * continued and no breakpoint will be shown to the user.
+   */
+  onPaused(event: Cdp.Debugger.PausedEvent): Promise<boolean>;
+
+  initialize(): Promise<void>;
   waitingForDebugger(): boolean;
   supportsCustomBreakpoints(): boolean;
   shouldCheckContentHash(): boolean;

--- a/src/test/node/node-runtime-attaching-attaches-children-of-child-processes.txt
+++ b/src/test/node/node-runtime-attaching-attaches-children-of-child-processes.txt
@@ -1,0 +1,16 @@
+{
+    allThreadsStopped : false
+    description : Paused
+    reason : step
+    threadId : <number>
+}
+foo @ ${fixturesDir}/child.js:1:1
+<anonymous> @ ${fixturesDir}/child.js:1:1
+Module._compile @ internal/modules/cjs/loader.js:778:30 <hidden: blackboxed>
+Module._extensions..js @ internal/modules/cjs/loader.js:789:10 <hidden: blackboxed>
+Module.load @ internal/modules/cjs/loader.js:653:32 <hidden: blackboxed>
+tryModuleLoad @ internal/modules/cjs/loader.js:593:12 <hidden: blackboxed>
+Module._load @ internal/modules/cjs/loader.js:585:3 <hidden: blackboxed>
+Module.runMain @ internal/modules/cjs/loader.js:831:12 <hidden: blackboxed>
+startup @ internal/bootstrap/node.js:283:19 <hidden: blackboxed>
+bootstrapNodeJSCore @ internal/bootstrap/node.js:622:3 <hidden: blackboxed>


### PR DESCRIPTION
A similar mechanism was needed for both scenarios, so they're here. The
NodeTarget now has a lifecycle object, and for node launches we hook into
the `initialized()` point to set a breakpoint on the main script file that
the user asked us to run.

We need to be paused to evaluate code, so the NodeAttacher uses the
initialized() point to request a pause, and when the first pause happens it
retrieves telemetry from the child process, and also installs the environment
variables necessary to instrument children. After doing this, any forked
children are detected automagially--you can try this out by running
`node demos/node/parent.js --inspect` and attaching to it; you can view and
debug in the child process.

The thorny point is around uninstallation when we detach; we'll have a bunch
of orphaned options, and subsequently spawned children will then run into some
issues when trying to connect back to the debug server. Ideally we could have
some piece of code that the inspectee runs automatically when the debugger
detaches, but as far as I can see there's no such mechanism in place. We could
try to do this manually when we disconnect, but not all disconnections
will be graceful.

So next I looked for a way to detect and disable inspection if we can find out
the server went away. And any detection needs to be synchronous so that we can
run it inline in our `--required` script, so we can't try to connect to the
debug server. I ended up just using a lease file. It's not perfect, but it
seems to do the trick.