### PR TITLE
Fix telemetry for server

### DIFF
--- a/src/dap/connection.ts
+++ b/src/dap/connection.ts
@@ -36,7 +36,7 @@ export default class Connection {
   protected _ready: (dap: Dap.Api) => void;
   private _logPath?: string;
   private _logPrefix = '';
-  private _telemetryReporter: TelemetryReporter | undefined;
+  protected _telemetryReporter: TelemetryReporter | undefined;
 
   constructor() {
     this._sequence = 1;


### PR DESCRIPTION
The telemetry wasn't working for the flat session server model because the ChildConnection don't user/call the init method of DapConnections.

I added extra code to make the telemetryReporter be set for these connections too....