### PR TITLE
feat: implement logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -584,20 +584,40 @@
                 "description": "%node.disableOptimisticBPs.description%",
                 "default": true
               },
-              "logging": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "cdp": {
-                    "type": "string",
-                    "description": "%node.launch.logging.cdp%"
+              "trace": {
+                "description": "%trace.description%",
+                "default": true,
+                "oneOf": [
+                  {
+                    "type": "boolean",
+                    "description": "%trace.boolean.description%"
                   },
-                  "dap": {
-                    "type": "string",
-                    "description": "%node.launch.logging.dap%"
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "console": {
+                        "type": "boolean",
+                        "description": "%trace.console.description%"
+                      },
+                      "level": {
+                        "enum": ["fatal", "error", "warn", "info", "verbose"],
+                        "description": "%trace.level.description%"
+                      },
+                      "logFile": {
+                        "type": ["string", "null"],
+                        "description": "%trace.logFile.description%"
+                      },
+                      "tags": {
+                        "type": "array",
+                        "description": "%trace.tags.description%",
+                        "items": {
+                          "enum": ["cdp", "dap", "runtime"]
+                        }
+                      }
+                    }
                   }
-                },
-                "description": "Logging configuration"
+                ]
               }
             }
           },
@@ -699,28 +719,40 @@
                 "description": "%node.disableOptimisticBPs.description%",
                 "default": true
               },
-              "logging": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "cdp": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "default": null,
-                    "description": "%node.launch.logging.cdp%"
+              "trace": {
+                "description": "%trace.description%",
+                "default": true,
+                "oneOf": [
+                  {
+                    "type": "boolean",
+                    "description": "%trace.boolean.description%"
                   },
-                  "dap": {
-                    "type": [
-                      "string",
-                      "null"
-                    ],
-                    "default": null,
-                    "description": "%node.launch.logging.dap%"
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "console": {
+                        "type": "boolean",
+                        "description": "%trace.console.description%"
+                      },
+                      "level": {
+                        "enum": ["fatal", "error", "warn", "info", "verbose"],
+                        "description": "%trace.level.description%"
+                      },
+                      "logFile": {
+                        "type": ["string", "null"],
+                        "description": "%trace.logFile.description%"
+                      },
+                      "tags": {
+                        "type": "array",
+                        "description": "%trace.tags.description%",
+                        "items": {
+                          "enum": ["cdp", "dap", "runtime"]
+                        }
+                      }
+                    }
                   }
-                },
-                "description": "%node.launch.logging%"
+                ]
               }
             }
           }
@@ -819,20 +851,40 @@
                 "description": "%chrome.sourceMaps.description%",
                 "default": true
               },
-              "logging": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "cdp": {
-                    "type": "string",
-                    "description": "%node.launch.logging.cdp%"
+              "trace": {
+                "description": "%trace.description%",
+                "default": true,
+                "oneOf": [
+                  {
+                    "type": "boolean",
+                    "description": "%trace.boolean.description%"
                   },
-                  "dap": {
-                    "type": "string",
-                    "description": "%node.launch.logging.dap%"
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "console": {
+                        "type": "boolean",
+                        "description": "%trace.console.description%"
+                      },
+                      "level": {
+                        "enum": ["fatal", "error", "warn", "info", "verbose"],
+                        "description": "%trace.level.description%"
+                      },
+                      "logFile": {
+                        "type": ["string", "null"],
+                        "description": "%trace.logFile.description%"
+                      },
+                      "tags": {
+                        "type": "array",
+                        "description": "%trace.tags.description%",
+                        "items": {
+                          "enum": ["cdp", "dap", "runtime"]
+                        }
+                      }
+                    }
                   }
-                },
-                "description": "Logging configuration"
+                ]
               },
               "userDataDir": {
                 "type": [
@@ -1056,20 +1108,40 @@
                     "description": "%node.disableOptimisticBPs.description%",
                     "default": true
                   },
-                  "logging": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                      "cdp": {
-                        "type": "string",
-                        "description": "%node.launch.logging.cdp%"
+                  "trace": {
+                    "description": "%trace.description%",
+                    "default": true,
+                    "oneOf": [
+                      {
+                        "type": "boolean",
+                        "description": "%trace.boolean.description%"
                       },
-                      "dap": {
-                        "type": "string",
-                        "description": "%node.launch.logging.dap%"
+                      {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "properties": {
+                          "console": {
+                            "type": "boolean",
+                            "description": "%trace.console.description%"
+                          },
+                          "level": {
+                            "enum": ["fatal", "error", "warn", "info", "verbose"],
+                            "description": "%trace.level.description%"
+                          },
+                          "logFile": {
+                            "type": ["string", "null"],
+                            "description": "%trace.logFile.description%"
+                          },
+                          "tags": {
+                            "type": "array",
+                            "description": "%trace.tags.description%",
+                            "items": {
+                              "enum": ["cdp", "dap", "runtime"]
+                            }
+                          }
+                        }
                       }
-                    },
-                    "description": "Logging configuration"
+                    ]
                   }
                 }
               }
@@ -1145,20 +1217,40 @@
                 "description": "%chrome.showAsyncStacks.description%",
                 "default": true
               },
-              "logging": {
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                  "cdp": {
-                    "type": "string",
-                    "description": "%node.launch.logging.cdp%"
+              "trace": {
+                "description": "%trace.description%",
+                "default": true,
+                "oneOf": [
+                  {
+                    "type": "boolean",
+                    "description": "%trace.boolean.description%"
                   },
-                  "dap": {
-                    "type": "string",
-                    "description": "%node.launch.logging.dap%"
+                  {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "console": {
+                        "type": "boolean",
+                        "description": "%trace.console.description%"
+                      },
+                      "level": {
+                        "enum": ["fatal", "error", "warn", "info", "verbose"],
+                        "description": "%trace.level.description%"
+                      },
+                      "logFile": {
+                        "type": ["string", "null"],
+                        "description": "%trace.logFile.description%"
+                      },
+                      "tags": {
+                        "type": "array",
+                        "description": "%trace.tags.description%",
+                        "items": {
+                          "enum": ["cdp", "dap", "runtime"]
+                        }
+                      }
+                    }
                   }
-                },
-                "description": "Logging configuration"
+                ]
               }
             }
           }

--- a/package.nls.json
+++ b/package.nls.json
@@ -6,6 +6,12 @@
   "add.browser.breakpoint": "Add Browser Breakpoint",
   "remove.browser.breakpoint": "Remove Browser Breakpoint",
   "remove.browser.breakpoint.all": "Remove All Browser Breakpoints",
+  "trace.description": "Configures what diagnostic output is produced.",
+  "trace.boolean.description": "Trace may be set to 'true' to write diagnostic logs to the disk.",
+  "trace.tags.description": "Configures what types of logs are recorded.",
+  "trace.logFile.description": "Configures where on disk logs are written.",
+  "trace.level.description": "Configures the level of logs recorded.",
+  "trace.console.description": "Configures whether logs are also returned to the debug console.",
 
 	"chrome.address.description": "TCP/IP address of debug port",
 	"chrome.baseUrl.description": "Base URL to resolve paths baseUrl. baseURL is trimmed when mapping URLs to the files on disk. Defaults to the launch URL domain.",

--- a/src/baseConfigurationProvider.ts
+++ b/src/baseConfigurationProvider.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { AnyResolvingConfiguration, ResolvedConfiguration } from './configuration';
+import { fulfillLoggerOptions } from './common/logging';
+
+/**
+ * Base configuration provider that handles some resolution around common
+ * options and handles errors.
+ */
+export abstract class BaseConfigurationProvider<T extends AnyResolvingConfiguration>
+  implements vscode.DebugConfigurationProvider {
+  constructor(protected readonly extensionContext: vscode.ExtensionContext) {}
+
+  /**
+   * @inheritdoc
+   */
+  public resolveDebugConfiguration(
+    folder: vscode.WorkspaceFolder | undefined,
+    config: vscode.DebugConfiguration,
+    token?: vscode.CancellationToken,
+  ): vscode.ProviderResult<vscode.DebugConfiguration> {
+    // We can't make the entire method async, as TS complains that it must
+    // return a Promise rather than a ProviderResult.
+    return (async () => {
+      try {
+        const resolved = await this.resolveDebugConfigurationAsync(folder, config as T, token);
+        return resolved && (await this.commonResolution(resolved));
+      } catch (err) {
+        vscode.window.showErrorMessage(err.message, { modal: true });
+      }
+    })();
+  }
+
+  /**
+   * Override me!
+   */
+  protected abstract async resolveDebugConfigurationAsync(
+    folder: vscode.WorkspaceFolder | undefined,
+    config: T,
+    token?: vscode.CancellationToken,
+  ): Promise<ResolvedConfiguration<T> | undefined>;
+
+  /**
+   * Fulfills resolution common between all resolver configs.
+   */
+  protected commonResolution(config: ResolvedConfiguration<T>): ResolvedConfiguration<T> {
+    config.trace = fulfillLoggerOptions(config.trace, this.extensionContext.logPath);
+    return config;
+  }
+}

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -13,6 +13,8 @@ import { generateBreakpointIds } from './adapter/breakpoints';
 import { AnyLaunchConfiguration } from './configuration';
 import { RawTelemetryReporterToDap } from './telemetry/telemetryReporter';
 import { filterErrorsReportedToTelemetry } from './telemetry/unhandledErrorReporter';
+import { logger } from './common/logging/logger';
+import { fulfillLoggerOptions, resolveLoggerOptions } from './common/logging';
 
 export interface BinderDelegate {
   acquireDap(target: Target): Promise<DapConnection>;
@@ -71,11 +73,11 @@ export class Binder implements Disposable {
       dap.on('threads', async () => ({ threads: [] }));
       dap.on('loadedSources', async () => ({ sources: [] }));
       dap.on('attach', async params => {
-        await this._boot(params as AnyLaunchConfiguration);
+        await this._boot(params as AnyLaunchConfiguration, dap);
         return {};
       });
       dap.on('launch', async params => {
-        await this._boot(params as AnyLaunchConfiguration);
+        await this._boot(params as AnyLaunchConfiguration, dap);
         return {};
       });
       dap.on('terminate', async () => {
@@ -93,7 +95,9 @@ export class Binder implements Disposable {
     });
   }
 
-  private async _boot(params: AnyLaunchConfiguration) {
+  private async _boot(params: AnyLaunchConfiguration, dap: Dap.Api) {
+    logger.setup(resolveLoggerOptions(dap, params.trace));
+
     if (params.rootPath)
       params.rootPath = urlUtils.platformPathToPreferredCase(params.rootPath);
     this._launchParams = params;
@@ -149,8 +153,6 @@ export class Binder implements Disposable {
     if (!cdp)
       return;
     const connection = await this._delegate.acquireDap(target);
-    if (this._launchParams && this._launchParams.logging && this._launchParams.logging.dap)
-      connection.setLogConfig(target.name(), this._launchParams.logging.dap);
     const dap = await connection.dap();
     const debugAdapter = new DebugAdapter(dap, this._launchParams && this._launchParams.rootPath || undefined, target.sourcePathResolver(), this._launchParams!);
     const thread = debugAdapter.createThread(target.name(), cdp, target);

--- a/src/chromeDebugConfigurationProvider.ts
+++ b/src/chromeDebugConfigurationProvider.ts
@@ -11,27 +11,22 @@ import {
 } from './configuration';
 import { NodeDebugConfigurationProvider } from './nodeDebugConfigurationProvider';
 import { Contributions } from './common/contributionUtils';
+import { BaseConfigurationProvider } from './baseConfigurationProvider';
 
 /**
  * Configuration provider for Chrome debugging.
  */
-export class ChromeDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
-  constructor(private readonly nodeProvider: NodeDebugConfigurationProvider) {}
-
-  public resolveDebugConfiguration(
-    folder: vscode.WorkspaceFolder | undefined,
-    config: vscode.DebugConfiguration,
-    token?: vscode.CancellationToken,
-  ): vscode.ProviderResult<vscode.DebugConfiguration> {
-    return this.resolveDebugConfigurationAsync(
-      folder,
-      config as ResolvingChromeConfiguration,
-    ).catch(err => {
-      return vscode.window.showErrorMessage(err.message, { modal: true }).then(_ => undefined); // abort launch
-    });
+export class ChromeDebugConfigurationProvider
+  extends BaseConfigurationProvider<ResolvingChromeConfiguration>
+  implements vscode.DebugConfigurationProvider {
+  constructor(
+    context: vscode.ExtensionContext,
+    private readonly nodeProvider: NodeDebugConfigurationProvider,
+  ) {
+    super(context);
   }
 
-  private async resolveDebugConfigurationAsync(
+  protected async resolveDebugConfigurationAsync(
     folder: vscode.WorkspaceFolder | undefined,
     config: ResolvingChromeConfiguration,
   ): Promise<AnyChromeConfiguration | undefined> {

--- a/src/common/logging/consoleLogSink.ts
+++ b/src/common/logging/consoleLogSink.ts
@@ -1,0 +1,72 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { ILogSink, ILogItem, LogLevel } from '.';
+import Dap from '../../dap/api';
+import Connection from '../../dap/connection';
+
+/**
+ * A log sink that writes to the console output.
+ */
+export class ConsoleLogSink implements ILogSink {
+  constructor(private readonly dap: Dap.Api) {}
+
+  /**
+   * @inheritdoc
+   */
+  public async setup() {
+    // no-op
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public dispose() {
+    // no-op
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public write(item: ILogItem<any>): void {
+    const category =
+      item.level > LogLevel.Error ? 'stderr' : item.level === LogLevel.Warn ? 'console' : 'stdout';
+    let output = `[${getLogLevel(item.level)}@${getFormattedTimeString()}] [${item.tag}]`;
+
+    if (item.message) {
+      output += ` ${item.message}`;
+    }
+
+    if (item.metadata) {
+      output += `: ${JSON.stringify(item.metadata)}`;
+    }
+
+    output += '\n';
+    this.dap.output(Connection.omitLoggingFor({ category, output }));
+  }
+}
+
+function getFormattedTimeString(): string {
+  const d = new Date();
+  const hourString = String(d.getUTCHours()).padStart(2, '0');
+  const minuteString = String(d.getUTCMinutes()).padStart(2, '0');
+  const secondString = String(d.getUTCSeconds()).padStart(2, '0');
+  const millisecondString = String(d.getUTCMilliseconds()).padStart(3, '0');
+  return `${hourString}:${minuteString}:${secondString}.${millisecondString}`;
+}
+
+function getLogLevel(level: LogLevel): string {
+  switch (level) {
+    case LogLevel.Fatal:
+      return 'FATAL';
+    case LogLevel.Error:
+      return 'ERROR';
+    case LogLevel.Warn:
+      return 'WARN';
+    case LogLevel.Verbose:
+      return 'VERB';
+    default:
+      return 'UNKNOWN';
+  }
+}

--- a/src/common/logging/consoleLogSink.ts
+++ b/src/common/logging/consoleLogSink.ts
@@ -64,6 +64,8 @@ function getLogLevel(level: LogLevel): string {
       return 'ERROR';
     case LogLevel.Warn:
       return 'WARN';
+    case LogLevel.Info:
+      return 'INFO';
     case LogLevel.Verbose:
       return 'VERB';
     default:

--- a/src/common/logging/fileLogSink.ts
+++ b/src/common/logging/fileLogSink.ts
@@ -1,0 +1,49 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { WriteStream, createWriteStream, mkdirSync } from 'fs';
+import { ILogSink, ILogItem } from '.';
+import Dap from '../../dap/api';
+import { dirname } from 'path';
+
+/**
+ * A log sink that writes to a file.
+ */
+export class FileLogSink implements ILogSink {
+  private readonly stream: WriteStream;
+
+  constructor(private readonly file: string, private readonly dap: Dap.Api) {
+    try {
+      mkdirSync(dirname(file), { recursive: true });
+    } catch {
+      // already exists
+    }
+
+    this.stream = createWriteStream(file);
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public async setup() {
+    this.dap.output({
+      category: 'console',
+      output: `Verbose logs are written to:\n${this.file}\n`,
+    });
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public dispose() {
+    this.stream.end();
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public write(item: ILogItem<any>): void {
+    this.stream.write(JSON.stringify(item) + '\n');
+  }
+}

--- a/src/common/logging/index.ts
+++ b/src/common/logging/index.ts
@@ -1,0 +1,162 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as fs from 'fs';
+import * as path from 'path';
+import * as mkdirp from 'mkdirp';
+import { Disposable } from '../events';
+import { IDisposable } from '../disposable';
+import { ILoggingConfiguration } from '../../configuration';
+import Dap from '../../dap/api';
+import { ConsoleLogSink } from './consoleLogSink';
+import { tmpdir } from 'os';
+import { FileLogSink } from './fileLogSink';
+
+export const enum LogLevel {
+  Verbose = 0,
+  Info,
+  Warn,
+  Error,
+  Fatal,
+  Never,
+}
+
+export const enum LogTag {
+  Runtime = 'runtime',
+  RuntimeException = 'runtime.exception',
+  RuntimeSourceMap = 'runtime.sourcemap',
+  CdpSend = 'cdp.send',
+  CdpReceive = 'cdp.receive',
+  DapSend = 'dap.send',
+  DapReceive = 'dap.receive',
+}
+
+/**
+ * Map of log tags, done this way so we have a compile-time check that we
+ * don't miss any tags.
+ */
+const allTagMap: { [K in LogTag]: null } = {
+  [LogTag.Runtime]: null,
+  [LogTag.RuntimeException]: null,
+  [LogTag.RuntimeSourceMap]: null,
+  [LogTag.CdpSend]: null,
+  [LogTag.CdpReceive]: null,
+  [LogTag.DapSend]: null,
+  [LogTag.DapReceive]: null,
+};
+
+/**
+ * List of all log tags.
+ */
+export const allLogTags = Object.keys(allTagMap) as ReadonlyArray<LogTag>;
+
+export interface ILogItem<T> {
+  timestamp: number;
+  message?: string;
+  metadata?: T;
+  tag: LogTag;
+  level: LogLevel;
+}
+
+/**
+ * Logger interface.
+ */
+export interface ILogger {
+  log(item: ILogItem<any>): void;
+  verbose(msg?: string, metadata?: any): void;
+  warn(msg?: string, metadata?: any): void;
+  error(msg?: string, metadata?: any): void;
+}
+
+/**
+ * A place where log information can be written.
+ */
+export interface ILogSink extends IDisposable {
+  /**
+   * Lifecycle hook called before the sink starts being used.
+   */
+  setup(): Promise<void>;
+
+  /**
+   * Writes an item to the log sink.
+   */
+  write(item: ILogItem<any>): void;
+}
+
+/**
+ * Setup options provided to MasterLogger instances.
+ */
+export interface ILoggerSetupOptions {
+  tags?: ReadonlyArray<string>;
+  showWelcome?: boolean;
+  level: LogLevel;
+  sinks: ReadonlyArray<ILogSink>;
+}
+
+const stringToLogLevel = (str: string) => {
+  switch (str.toLowerCase()) {
+    case 'verbose':
+      return LogLevel.Verbose;
+    case 'info':
+      return LogLevel.Info;
+    case 'warn':
+      return LogLevel.Warn;
+    case 'error':
+      return LogLevel.Error;
+    case 'fatal':
+      return LogLevel.Fatal;
+    default:
+      throw new Error(`Unknown log level "${str}"`);
+  }
+};
+
+/**
+ * Fulfills the partial config to a full logging configuration.
+ */
+export function fulfillLoggerOptions(
+  config?: boolean | Partial<ILoggingConfiguration>,
+  logDir = tmpdir(),
+): ILoggingConfiguration {
+  if (config === false) {
+    return { console: false, level: 'fatal', logFile: null, tags: [] };
+  }
+
+  const defaults: ILoggingConfiguration = {
+    console: false,
+    level: 'verbose',
+    logFile: path.join(logDir, 'vscode-debugadapter.json'),
+    tags: [],
+  };
+
+  if (config === true) {
+    return defaults;
+  }
+
+  return { ...defaults, ...config };
+}
+
+/**
+ * Creates logger setup options from the given configuration.
+ */
+export function resolveLoggerOptions(
+  dap: Dap.Api,
+  config: boolean | Partial<ILoggingConfiguration>,
+): ILoggerSetupOptions {
+  const fulfilled = fulfillLoggerOptions(config);
+  const options = {
+    tags: fulfilled.tags,
+    level: fulfilled.level === undefined ? LogLevel.Verbose : stringToLogLevel(fulfilled.level),
+    sinks: <ILogSink[]>[],
+  };
+
+  if (fulfilled.console) {
+    options.sinks.push(new ConsoleLogSink(dap));
+  }
+
+  if (fulfilled.logFile) {
+    options.sinks.push(new FileLogSink(fulfilled.logFile, dap));
+  }
+
+  return options;
+}

--- a/src/common/logging/index.ts
+++ b/src/common/logging/index.ts
@@ -22,8 +22,9 @@ export const enum LogLevel {
   Never,
 }
 
-export const enum LogTag {
+export enum LogTag {
   Runtime = 'runtime',
+  RuntimeWelcome = 'runtime.welcome',
   RuntimeException = 'runtime.exception',
   RuntimeSourceMap = 'runtime.sourcemap',
   CdpSend = 'cdp.send',
@@ -33,23 +34,9 @@ export const enum LogTag {
 }
 
 /**
- * Map of log tags, done this way so we have a compile-time check that we
- * don't miss any tags.
- */
-const allTagMap: { [K in LogTag]: null } = {
-  [LogTag.Runtime]: null,
-  [LogTag.RuntimeException]: null,
-  [LogTag.RuntimeSourceMap]: null,
-  [LogTag.CdpSend]: null,
-  [LogTag.CdpReceive]: null,
-  [LogTag.DapSend]: null,
-  [LogTag.DapReceive]: null,
-};
-
-/**
  * List of all log tags.
  */
-export const allLogTags = Object.keys(allTagMap) as ReadonlyArray<LogTag>;
+export const allLogTags = Object.keys(LogTag) as ReadonlyArray<keyof typeof LogTag>;
 
 export interface ILogItem<T> {
   timestamp: number;

--- a/src/common/logging/logger.ts
+++ b/src/common/logging/logger.ts
@@ -1,0 +1,158 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { Disposable } from '../events';
+import { ILogger, ILogItem, ILogSink, ILoggerSetupOptions, LogLevel, LogTag, allLogTags } from '.';
+
+const packageJson = require('../../../package.json');
+
+/**
+ * Implementation of ILogger for the extension. You should probably use the
+ * global const `logger` instance.
+ */
+export class Logger implements ILogger, Disposable {
+  /**
+   * The target of the logger. Either a list of sinks, or a queue of items
+   * to write once we get sinks.
+   */
+  private logTarget: { queue: ILogItem<any>[] } | { sinks: ILogSink[] } = { queue: [] };
+
+  /**
+   * Minimum log level.
+   */
+  private minLevel = LogLevel.Verbose;
+
+  /**
+   * Log tag filter.
+   */
+  private tags?: ReadonlySet<string>;
+
+  /**
+   * @inheritdoc
+   */
+  public verbose(tag: LogTag, msg?: string, metadata?: any): void {
+    this.log({
+      tag,
+      timestamp: Date.now(),
+      message: msg,
+      metadata,
+      level: LogLevel.Verbose,
+    });
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public warn(tag: LogTag, msg?: string, metadata?: any): void {
+    this.log({
+      tag,
+      timestamp: Date.now(),
+      message: msg,
+      metadata,
+      level: LogLevel.Warn,
+    });
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public error(tag: LogTag, msg?: string, metadata?: any): void {
+    this.log({
+      tag,
+      timestamp: Date.now(),
+      message: msg,
+      metadata,
+      level: LogLevel.Error,
+    });
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public fatal(tag: LogTag, msg?: string, metadata?: any): void {
+    this.log({
+      tag,
+      timestamp: Date.now(),
+      message: msg,
+      metadata,
+      level: LogLevel.Fatal,
+    });
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public log(data: ILogItem<any>): void {
+    if ('queue' in this.logTarget) {
+      this.logTarget.queue.push(data);
+      return;
+    }
+
+    if (data.level < this.minLevel) {
+      return;
+    }
+
+    if (this.tags && !this.tags.has(data.tag)) {
+      return;
+    }
+
+    for (const sink of this.logTarget.sinks) {
+      sink.write(data);
+    }
+  }
+
+  /**
+   * @inheritdoc
+   */
+  dispose(): void {
+    if ('sinks' in this.logTarget) {
+      for (const target of this.logTarget.sinks) {
+        target.dispose();
+      }
+      this.logTarget = { queue: [] };
+    }
+  }
+
+  /**
+   * Adds the given sinks to the loggers. Plays back any items buffered in the queue.
+   */
+  public async setup(options: ILoggerSetupOptions): Promise<void> {
+    this.minLevel = options.level;
+
+    if (options.tags && options.tags.length) {
+      // Add all log tags that equal or are children of the one given in the
+      // options. For instance, `cdp` adds the tags `cdp`, `cdp.send`, etc.
+      this.tags = new Set(
+        options.tags
+          .map(src => allLogTags.filter(t => t === src || t.startsWith(`${src}.`)))
+          .reduce((acc, tags) => [...acc, ...tags], []),
+      );
+    } else {
+      this.tags = undefined;
+    }
+
+    await Promise.all(options.sinks.map(s => s.setup()));
+
+    if ('sinks' in this.logTarget) {
+      this.logTarget.sinks.push(...options.sinks);
+      return;
+    }
+
+    if (options.showWelcome !== false) {
+      this.verbose(LogTag.Runtime, `${packageJson.name} v${packageJson.version} started`);
+    }
+
+    const prevTarget = this.logTarget;
+    this.logTarget = { sinks: options.sinks.slice() };
+
+    // intentionally re-`log()` instead of writing directly to sinks so that
+    // and tag or level filtering is applied.
+    prevTarget.queue.forEach(m => this.log(m));
+  }
+}
+
+/**
+ * Global logger instance.
+ */
+export const logger = new Logger();

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -26,6 +26,33 @@ export const enum OutputSource {
   Stdio = 'std',
 }
 
+export interface ILoggingConfiguration {
+  /**
+   * Configures whether logs are also returned to the debug console.
+   * Defaults to false.
+   */
+  console: boolean;
+
+  /**
+   * Configures the level of logs recorded. Defaults to "Verbose".
+   */
+  level: string;
+
+  /**
+   * Configures where on disk logs are written. If this is null, no logs
+   * will be written, otherwise the extension log directory (in VS Code) or
+   * OS tmpdir (in VS) will be used.
+   */
+  logFile: string | null;
+
+  /**
+   * Configures what types of logs recorded. For instance, `cdp` will log all
+   * CDP protocol messages. If this is empty or not provided, tags will not
+   * be filtered.
+   */
+  tags: ReadonlyArray<string>;
+}
+
 interface IBaseConfiguration extends IMandatedConfiguration, Dap.LaunchParams {
   /**
    * TCP/IP address of process to be debugged (for Node.js >= 5.0 only).
@@ -72,16 +99,7 @@ interface IBaseConfiguration extends IMandatedConfiguration, Dap.LaunchParams {
   /**
    * Logging configuration
    */
-  logging: {
-    /**
-     * Path to the log file for Chrome DevTools Protocol messages.
-     */
-    cdp: string | null;
-    /**
-     * Path to the log file for Debug Adapter Protocol messages.
-     */
-    dap: string | null;
-  };
+  trace: boolean | Partial<ILoggingConfiguration>;
 
   /**
    * todo: difference between this and webRoot?
@@ -132,13 +150,6 @@ export interface INodeBaseConfiguration extends IBaseConfiguration {
    * Path to the remote directory containing the program.
    */
   remoteRoot: string | null;
-
-  /**
-   * Produce diagnostic output. Instead of setting this to true you can
-   * list one or more selectors separated with commas. The 'verbose' selector
-   * enables very detailed output.
-   */
-  trace: boolean | string;
 
   /**
    * Don't set breakpoints in any file until a sourcemap has been
@@ -304,19 +315,34 @@ export type AnyNodeConfiguration = INodeAttachConfiguration | INodeLaunchConfigu
 export type AnyChromeConfiguration = IChromeAttachConfiguration | IChromeLaunchConfiguration;
 export type AnyLaunchConfiguration = AnyChromeConfiguration | AnyNodeConfiguration;
 
-export type ResolvingNodeAttachConfiguration = IMandatedConfiguration & Partial<INodeAttachConfiguration>;
-export type ResolvingNodeLaunchConfiguration = IMandatedConfiguration & Partial<INodeLaunchConfiguration>;
-export type ResolvingNodeConfiguration = ResolvingNodeAttachConfiguration | ResolvingNodeLaunchConfiguration;
+export type ResolvingNodeAttachConfiguration = IMandatedConfiguration &
+  Partial<INodeAttachConfiguration>;
+export type ResolvingNodeLaunchConfiguration = IMandatedConfiguration &
+  Partial<INodeLaunchConfiguration>;
+export type ResolvingNodeConfiguration =
+  | ResolvingNodeAttachConfiguration
+  | ResolvingNodeLaunchConfiguration;
 export type ResolvingChromeConfiguration = IMandatedConfiguration & Partial<AnyChromeConfiguration>;
+export type AnyResolvingConfiguration = ResolvingChromeConfiguration | ResolvingNodeConfiguration;
+
+/**
+ * Where T subtypes AnyResolvingConfiguration, gets the resolved version of T.
+ */
+export type ResolvedConfiguration<T> = T extends ResolvingNodeAttachConfiguration
+  ? INodeAttachConfiguration
+  : T extends ResolvingNodeLaunchConfiguration
+  ? INodeLaunchConfiguration
+  : T extends ResolvingNodeConfiguration
+  ? AnyNodeConfiguration
+  : T extends ResolvingChromeConfiguration
+  ? AnyChromeConfiguration
+  : never;
 
 export const baseDefaults: IBaseConfiguration = {
   type: '',
   name: '',
   request: '',
-  logging: {
-    cdp: null,
-    dap: null,
-  },
+  trace: false,
   address: 'localhost',
   outputCapture: OutputSource.Console,
   port: 9229,

--- a/src/dap/connection.ts
+++ b/src/dap/connection.ts
@@ -6,6 +6,8 @@ import Dap from './api';
 import { HighResolutionTime } from '../utils/performance';
 import { TelemetryReporter, RawTelemetryReporterToDap } from '../telemetry/telemetryReporter';
 import { installUnhandledErrorReporter } from '../telemetry/unhandledErrorReporter';
+import { logger } from '../common/logging/logger';
+import { LogTag } from '../common/logging';
 
 export interface Message {
   sessionId?: string;
@@ -25,6 +27,7 @@ let isFirstDapConnectionEver = true;
 
 export default class Connection {
   private static _TWO_CRLF = '\r\n\r\n';
+  private static readonly logOmittedCalls = new WeakSet<object>();
 
   private _writableStream?: NodeJS.WritableStream;
   private _rawData: Buffer;
@@ -37,8 +40,6 @@ export default class Connection {
   private _dap: Promise<Dap.Api>;
 
   protected _ready: (dap: Dap.Api) => void;
-  private _logPath?: string;
-  private _logPrefix = '';
   protected _telemetryReporter: TelemetryReporter | undefined;
 
   constructor() {
@@ -46,6 +47,16 @@ export default class Connection {
     this._rawData = new Buffer(0);
     this._ready = () => {};
     this._dap = new Promise<Dap.Api>(f => this._ready = f);
+  }
+
+  /**
+   * Omits logging a call when the given object is used as parameters for
+   * a method call. This is, at the moment, solely used to prevent logging
+   * log output and getting into an feedback loop with the ConsoleLogSink.
+   */
+  public static omitLoggingFor<T extends object>(obj: T): T {
+    Connection.logOmittedCalls.add(obj);
+    return obj;
   }
 
   public init(inStream: NodeJS.ReadableStream, outStream: NodeJS.WritableStream) {
@@ -73,11 +84,6 @@ export default class Connection {
 
   public dap(): Promise<Dap.Api> {
     return this._dap;
-  }
-
-  public setLogConfig(prefix: string, path?: string) {
-    this._logPrefix = prefix;
-    this._logPath = path;
   }
 
   _createApi(): Dap.Api {
@@ -164,8 +170,11 @@ export default class Connection {
   _send(message: Message) {
     message.seq = this._sequence++;
     const json = JSON.stringify(message);
-    if (this._logPath)
-      require('fs').appendFileSync(this._logPath, `◀ SEND [${this._logPrefix}] ${json}\n`);
+
+    if (!Connection.logOmittedCalls.has(message.body)) {
+      logger.verbose(LogTag.DapSend, undefined, { message });
+    }
+
     const data = `Content-Length: ${Buffer.byteLength(json, 'utf8')}\r\n\r\n${json}`;
     if (!this._writableStream) {
       console.error('Writing to a closed connection');
@@ -246,9 +255,8 @@ export default class Connection {
           this._contentLength = -1;
           if (message.length > 0) {
             try {
-              if (this._logPath)
-                require('fs').appendFileSync(this._logPath, `RECV ► [${this._logPrefix}] ${message}\n`);
               let msg: Message = JSON.parse(message);
+              logger.verbose(LogTag.DapReceive, undefined, { message: msg });
               this._onMessage(msg, receivedTime);
             }
             catch (e) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,8 +18,8 @@ export function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand(Contributions.AttachProcessCommand, attachProcess),
   );
 
-  const nodeConfigProvider = new NodeDebugConfigurationProvider();
-  const chromeConfigProvider = new ChromeDebugConfigurationProvider(nodeConfigProvider);
+  const nodeConfigProvider = new NodeDebugConfigurationProvider(context,);
+  const chromeConfigProvider = new ChromeDebugConfigurationProvider(context, nodeConfigProvider);
 
   context.subscriptions.push(
     vscode.debug.registerDebugConfigurationProvider(

--- a/src/int-chrome/testSetup.ts
+++ b/src/int-chrome/testSetup.ts
@@ -31,7 +31,7 @@ function formLaunchArgs(
   launchArgs.type = 'pwa-chrome' as any; // TODO@rob
   launchArgs.logging = { dap: '/tmp/dap.log', cdp: '/tmp/cdp.log' };
   launchArgs.sourceMapPathOverrides = {};
-  launchArgs.trace = 'verbose';
+  launchArgs.trace = true;
   launchArgs.logTimestamps = true;
   launchArgs.disableNetworkCache = true;
   launchArgs.logFilePath = getDebugAdapterLogFilePath(testTitle);

--- a/src/nodeDebugConfigurationProvider.ts
+++ b/src/nodeDebugConfigurationProvider.ts
@@ -16,6 +16,7 @@ import { Contributions } from './common/contributionUtils';
 import { NvmResolver, INvmResolver } from './targets/node/nvmResolver';
 import { EnvironmentVars } from './common/environmentVars';
 import { resolveProcessId } from './ui/processPicker';
+import { BaseConfigurationProvider } from './baseConfigurationProvider';
 
 const localize = nls.loadMessageBundle();
 
@@ -30,25 +31,17 @@ const breakpointLanguages: ReadonlyArray<
  * close to 1:1 drop-in, this is nearly identical to the original vscode-
  * node-debug, with support for some legacy options (mern, useWSL) removed.
  */
-export class NodeDebugConfigurationProvider implements vscode.DebugConfigurationProvider {
-  constructor(private readonly nvmResolver: INvmResolver = new NvmResolver()) {}
-
-  /**
-   * Try to add all missing attributes to the debug configuration being launched.
-   */
-  public async resolveDebugConfiguration(
-    folder: vscode.WorkspaceFolder | undefined,
-    config: vscode.DebugConfiguration,
-  ): Promise<vscode.DebugConfiguration | undefined> {
-    try {
-      return this.resolveDebugConfigurationAsync(folder, config as ResolvingNodeConfiguration);
-    } catch (err) {
-      await vscode.window.showErrorMessage(err.message, { modal: true });
-      return;
-    }
+export class NodeDebugConfigurationProvider
+  extends BaseConfigurationProvider<ResolvingNodeConfiguration>
+  implements vscode.DebugConfigurationProvider {
+  constructor(
+    context: vscode.ExtensionContext,
+    private readonly nvmResolver: INvmResolver = new NvmResolver(),
+  ) {
+    super(context);
   }
 
-  private async resolveDebugConfigurationAsync(
+  protected async resolveDebugConfigurationAsync(
     folder: vscode.WorkspaceFolder | undefined,
     config: ResolvingNodeConfiguration,
   ): Promise<AnyNodeConfiguration | undefined> {

--- a/src/targets/browser/browserAttacher.ts
+++ b/src/targets/browser/browserAttacher.ts
@@ -67,8 +67,6 @@ export class BrowserAttacher implements Launcher {
       return;
     }
 
-    if (params.logging && params.logging.cdp)
-      connection.setLogConfig(String(params.port || ''), params.logging.cdp);
     this._connection = connection;
     connection.onDisconnected(() => {
       this._connection = undefined;

--- a/src/targets/browser/browserLauncher.ts
+++ b/src/targets/browser/browserLauncher.ts
@@ -97,8 +97,6 @@ export class BrowserLauncher implements Launcher {
       return localize('error.browserLaunchError', 'Unable to launch browser: "{0}"', e.message);
     }
 
-    if (params.logging && params.logging.cdp)
-      connection.setLogConfig(params.url || '', params.logging.cdp);
     connection.onDisconnected(() => {
       this._onTerminatedEmitter.fire({ code: 0, killed: true });
     }, undefined, this._disposables);

--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -275,7 +275,6 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
       connection,
       cdp,
       targetInfo,
-      this.run.params,
     );
 
     target.setParent(targetInfo.openerId ? this.targets.get(targetInfo.openerId) : undefined);

--- a/src/targets/node/nodeTarget.ts
+++ b/src/targets/node/nodeTarget.ts
@@ -35,7 +35,6 @@ export class NodeTarget implements Target {
     public readonly connection: Connection,
     cdp: Cdp.Api,
     targetInfo: Cdp.Target.TargetInfo,
-    args: AnyNodeConfiguration,
   ) {
     this.connection = connection;
     this._cdp = cdp;
@@ -46,8 +45,6 @@ export class NodeTarget implements Target {
     if (targetInfo.title)
       this._targetName = `${basename(targetInfo.title)} [${targetInfo.targetId}]`;
     else this._targetName = `[${targetInfo.targetId}]`;
-    if (args.logging && args.logging.cdp)
-      connection.setLogConfig(this._targetName, args.logging.cdp);
 
     cdp.Target.on('targetDestroyed', () => this.connection.close());
     connection.onDisconnected(_ => this._disconnected());

--- a/src/targets/sourcePathResolver.ts
+++ b/src/targets/sourcePathResolver.ts
@@ -12,6 +12,8 @@ import {
 import * as path from 'path';
 import { isFileUrl } from '../common/urlUtils';
 import { baseDefaults } from '../configuration';
+import { logger } from '../common/logging/logger';
+import { LogTag } from '../common/logging';
 
 export interface ISourcePathResolverOptions {
   sourceMapOverrides: { [key: string]: string };
@@ -44,8 +46,7 @@ export abstract class SourcePathResolverBase<T extends ISourcePathResolverOption
     let localPath = join(this.options.localRoot, relativePath);
 
     localPath = fixDriveLetter(localPath);
-    // todo: #34
-    // logger.log(`Mapped remoteToLocal: ${remotePath} -> ${localPath}`);
+    logger.verbose(LogTag.RuntimeSourceMap, `Mapped remoteToLocal: ${remotePath} -> ${localPath}`);
     return localPath;
   }
 
@@ -64,8 +65,7 @@ export abstract class SourcePathResolverBase<T extends ISourcePathResolverOption
     let remotePath = join(this.options.remoteRoot, relPath);
 
     remotePath = fixDriveLetterAndSlashes(remotePath, /*uppercaseDriveLetter=*/ true);
-    // todo: #34
-    // logger.log(`Mapped localToRemote: ${localPath} -> ${remotePath}`);
+    logger.verbose(LogTag.RuntimeSourceMap, `Mapped localToRemote: ${localPath} -> ${remotePath}`);
     return remotePath;
   }
 
@@ -83,19 +83,23 @@ export abstract class SourcePathResolverBase<T extends ISourcePathResolverOption
     // Iterate the key/vals, only apply the first one that matches.
     for (let leftPattern of sortedOverrideKeys) {
       const rightPattern = sourceMapOverrides[leftPattern];
-      // const entryStr = `"${leftPattern}": "${rightPattern}"`;
+      const entryStr = `"${leftPattern}": "${rightPattern}"`;
 
       const asterisks = leftPattern.match(/\*/g) || [];
       if (asterisks.length > 1) {
-        // todo: #34
-        // logger.log(`Warning: only one asterisk allowed in a sourceMapPathOverrides entry - ${entryStr}`);
+        logger.warn(
+          LogTag.RuntimeSourceMap,
+          `Warning: only one asterisk allowed in a sourceMapPathOverrides entry - ${entryStr}`,
+        );
         continue;
       }
 
       const replacePatternAsterisks = rightPattern.match(/\*/g) || [];
       if (replacePatternAsterisks.length > asterisks.length) {
-        // todo: #34
-        // logger.log(`Warning: the right side of a sourceMapPathOverrides entry must have 0 or 1 asterisks - ${entryStr}}`);
+        logger.warn(
+          LogTag.RuntimeSourceMap,
+          `The right side of a sourceMapPathOverrides entry must have 0 or 1 asterisks - ${entryStr}}`,
+        );
         continue;
       }
 
@@ -111,8 +115,10 @@ export abstract class SourcePathResolverBase<T extends ISourcePathResolverOption
       const wildcardValue = overridePatternMatches[1];
       let mappedPath = rightPattern.replace(/\*/g, wildcardValue);
 
-      // todo: #34
-      // logger.log(`SourceMap: mapping ${sourcePath} => ${mappedPath}, via sourceMapPathOverrides entry - ${entryStr}`);
+      logger.verbose(
+        LogTag.RuntimeSourceMap,
+        `SourceMap: mapping ${sourcePath} => ${mappedPath}, via sourceMapPathOverrides entry - ${entryStr}`,
+      );
       return properJoin(mappedPath);
     }
 

--- a/src/telemetry/unhandledErrorReporter.ts
+++ b/src/telemetry/unhandledErrorReporter.ts
@@ -3,6 +3,8 @@
 
 import * as path from 'path';
 import { extractErrorDetails, RawTelemetryReporter } from './telemetryReporter';
+import { logger } from '../common/logging/logger';
+import { LogTag } from '../common/logging';
 
 type ExceptionType = 'uncaughtException' | 'unhandledRejection';
 
@@ -11,39 +13,53 @@ export function installUnhandledErrorReporter(telemetryReporter: RawTelemetryRep
     if (shouldReportThisError(exception)) {
       reportErrorTelemetry(telemetryReporter, exception, 'uncaughtException');
 
-      // TODO: Print this to the log
-      console.error(`******** Unhandled error in debug adapter: ${safeGetErrDetails(exception)}`);
-      }
+      logger.error(
+        LogTag.RuntimeException,
+        'Unhandled error in debug adapter',
+        safeGetErrDetails(exception),
+      );
+    }
   });
 
   process.addListener('unhandledRejection', (rejection: unknown) => {
     if (shouldReportThisError(rejection)) {
       reportErrorTelemetry(telemetryReporter, rejection, 'unhandledRejection');
 
-      // TODO: Print this to the log
-      console.error(`******** Unhandled error in debug adapter - Unhandled promise rejection: ${safeGetErrDetails(rejection)}`);
+      logger.error(
+        LogTag.RuntimeException,
+        'Unhandled promise rejection',
+        safeGetErrDetails(rejection),
+      );
     }
   });
-
 }
 
-function reportErrorTelemetry(telemetryReporter: RawTelemetryReporter, err: unknown, exceptionType: ExceptionType): void {
+function reportErrorTelemetry(
+  telemetryReporter: RawTelemetryReporter,
+  err: unknown,
+  exceptionType: ExceptionType,
+): void {
   const properties = { ...extractErrorDetails(err), successful: 'false', exceptionType };
 
   telemetryReporter.report('error', properties);
 }
 
-function safeGetErrDetails(err: unknown): string {
-  let errMsg: string;
+const isErrorObjectLike = (err: unknown): err is Error => err && 'stack' in <Error>err;
 
-  try {
-    const possibleStack = (err && (<Error>err).stack);
-    errMsg = possibleStack ? possibleStack : JSON.stringify(err);
-  } catch (e) {
-    errMsg = 'Error while handling previous error: ' + e.stack;
+function safeGetErrDetails(err: unknown) {
+  if (!err) {
+    return String(err);
   }
 
-  return errMsg;
+  if (isErrorObjectLike(err)) {
+    return {
+      stack: err.stack,
+      message: err.message,
+      ...err,
+    };
+  }
+
+  return typeof err === 'object' ? err : String(err);
 }
 
 const debugAdapterFolder = path.dirname(path.dirname(path.dirname(__dirname)));
@@ -51,8 +67,10 @@ const debugAdapterFolder = path.dirname(path.dirname(path.dirname(__dirname)));
 function shouldReportThisError(error: any): boolean {
   // In VS Code, this debug adapter runs inside the extension host process, so we could capture
   // errors from other pieces of software here. We check to make sure this is our error before reporting it
-  return !shouldFilterErrorsReportedToTelemetry
-    || (error && typeof error.stack === 'string' && error.stack.includes(debugAdapterFolder));
+  return (
+    !shouldFilterErrorsReportedToTelemetry ||
+    (error && typeof error.stack === 'string' && error.stack.includes(debugAdapterFolder))
+  );
 }
 
 let shouldFilterErrorsReportedToTelemetry = false;

--- a/src/test/common/logging.test.ts
+++ b/src/test/common/logging.test.ts
@@ -1,0 +1,53 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { expect } from 'chai';
+import { stub, SinonStub } from 'sinon';
+import { Logger } from '../../common/logging/logger';
+import { LogTag, LogLevel } from '../../common/logging';
+
+describe('Logger', () => {
+  let sink: { write: SinonStub; setup: SinonStub; dispose: SinonStub };
+  let logger: Logger;
+
+  beforeEach(() => {
+    sink = { write: stub(), setup: stub().resolves(), dispose: stub() };
+    logger = new Logger();
+  });
+
+  it('buffers and logs messages once sinks are attached', async () => {
+    logger.verbose(LogTag.Runtime, 'Hello world!');
+    await logger.setup({ level: LogLevel.Verbose, sinks: [sink] });
+    expect(sink.write.args[0][0]).to.containSubset({
+      tag: LogTag.Runtime,
+      message: 'Hello world!',
+      level: LogLevel.Verbose,
+    });
+  });
+
+  it('applies level filters before and after attach', async () => {
+    logger.verbose(LogTag.Runtime, 'a');
+    logger.warn(LogTag.Runtime, 'b');
+    await logger.setup({ level: LogLevel.Warn, sinks: [sink], showWelcome: false });
+    logger.verbose(LogTag.Runtime, 'c');
+    logger.warn(LogTag.Runtime, 'd');
+    expect(sink.write.args.map(a => a[0].message)).to.deep.equal(['b', 'd']);
+  });
+
+  it('applies tag filters before and after attach', async () => {
+    logger.verbose(LogTag.DapSend, 'a');
+    logger.warn(LogTag.Runtime, 'b');
+    logger.warn(LogTag.RuntimeException, 'c');
+    await logger.setup({
+      level: LogLevel.Verbose,
+      tags: [LogTag.Runtime],
+      sinks: [sink],
+      showWelcome: false,
+    });
+    logger.verbose(LogTag.DapSend, 'd');
+    logger.warn(LogTag.Runtime, 'e');
+    logger.warn(LogTag.RuntimeException, 'f');
+    expect(sink.write.args.map(a => a[0].message)).to.deep.equal(['b', 'c', 'e', 'f']);
+  });
+});


### PR DESCRIPTION
This is inspired by the previous debug adapter in functionality. It
buffers written logs until we attach sinks, as we can log information
before the DAP or extension context is available. It uses the existing
`trace` option, but is now (optionally) an object with some additonal information
which allows for filtering; since we now log all DAP and CDP messages,
I figured this could be useful during development to cut down on some
noise.

```ts
export interface ILoggingConfiguration {
  /**
   * Configures whether logs are also returned to the debug console.
   * Defaults to false.
   */
  console: boolean;

  /**
   * Configures the level of logs recorded. Defaults to "Verbose".
   */
  level: string;

  /**
   * Configures where on disk logs are written. If this is null, no logs
   * will be written, otherwise the extension log directory (in VS Code) or
   * OS tmpdir (in VS) will be used.
   */
  logFile: string | null;

  /**
   * Configures what types of logs recorded. For instance, `cdp` will log all
   * CDP protocol messages. If this is empty or not provided, tags will not
   * be filtered.
   */
  tags: ReadonlyArray<string>;
}
```

Logs are written to the file as JSON. I'll modify the existing log
viewer tool to be able to read JSON over its previous line-parsing logic.