### PR TITLE
feat: option support in browser attach

### DIFF
--- a/demos/web-worker/.vscode/launch.json
+++ b/demos/web-worker/.vscode/launch.json
@@ -7,12 +7,22 @@
     {
       "type": "pwa-chrome",
       "request": "launch",
-      "name": "Web page 2",
+      "name": "[web-worker] launch with server",
       "url": "http://localhost:5002",
+      "trace": true,
       "server": {
         "program": "${workspaceFolder}/node_modules/serve/bin/serve.js",
         "args": ["-p", "5002"]
       },
+    },
+    {
+      "type": "pwa-chrome",
+      "request": "attach",
+      "name": "[web-worker] attach to browser",
+      "address": "127.0.0.1",
+      "trace": true,
+      "port": 9222,
+      "url": "http://localhost:5002",
     }
   ]
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -13,6 +13,7 @@
   "trace.level.description": "Configures the level of logs recorded.",
   "trace.console.description": "Configures whether logs are also returned to the debug console.",
 
+  "chrome.attach.noMatchingTarget": "Can't find a valid target that matches {0} within {1}ms",
 	"chrome.address.description": "TCP/IP address of debug port",
 	"chrome.baseUrl.description": "Base URL to resolve paths baseUrl. baseURL is trimmed when mapping URLs to the files on disk. Defaults to the launch URL domain.",
 	"chrome.cwd.description": "Optional working directory for the runtime executable.",

--- a/src/common/logging/fileLogSink.ts
+++ b/src/common/logging/fileLogSink.ts
@@ -7,6 +7,18 @@ import { ILogSink, ILogItem } from '.';
 import Dap from '../../dap/api';
 import { dirname } from 'path';
 
+const replacer = (_key: string, value: unknown): any => {
+  if (value instanceof Error) {
+    return {
+      message: value.message,
+      stack: value.stack,
+      ...value
+    };
+  }
+
+  return value;
+}
+
 /**
  * A log sink that writes to a file.
  */
@@ -44,6 +56,6 @@ export class FileLogSink implements ILogSink {
    * @inheritdoc
    */
   public write(item: ILogItem<any>): void {
-    this.stream.write(JSON.stringify(item) + '\n');
+    this.stream.write(JSON.stringify(item, replacer) + '\n');
   }
 }

--- a/src/common/logging/index.ts
+++ b/src/common/logging/index.ts
@@ -21,6 +21,7 @@ export const enum LogLevel {
 
 export enum LogTag {
   Runtime = 'runtime',
+  RuntimeTarget = 'runtime.target',
   RuntimeWelcome = 'runtime.welcome',
   RuntimeException = 'runtime.exception',
   RuntimeSourceMap = 'runtime.sourcemap',

--- a/src/common/logging/logger.ts
+++ b/src/common/logging/logger.ts
@@ -32,6 +32,19 @@ export class Logger implements ILogger, Disposable {
   /**
    * @inheritdoc
    */
+  public info(tag: LogTag, msg?: string, metadata?: any): void {
+    this.log({
+      tag,
+      timestamp: Date.now(),
+      message: msg,
+      metadata,
+      level: LogLevel.Info,
+    });
+  }
+
+  /**
+   * @inheritdoc
+   */
   public verbose(tag: LogTag, msg?: string, metadata?: any): void {
     this.log({
       tag,

--- a/src/common/urlUtils.ts
+++ b/src/common/urlUtils.ts
@@ -5,6 +5,9 @@ import { URL } from 'url';
 import * as fs from 'fs';
 import * as path from 'path';
 import { fixDriveLetterAndSlashes } from './pathUtils';
+import Cdp from '../cdp/api';
+import { escapeRegexSpecialChars } from './sourceUtils';
+import { AnyChromeConfiguration } from '../configuration';
 
 export async function fetch(url: string): Promise<string> {
   if (url.startsWith('data:')) {
@@ -200,4 +203,52 @@ export const isLoopback = (address: string) => {
   } catch {
     return loopbacks.has(address);
   }
+};
+
+/**
+ * Creates a target filter function for the given Chrome configuration.
+ */
+export const createTargetFilterForConfig = (
+  config: AnyChromeConfiguration,
+): ((t: Cdp.Target.TargetInfo) => boolean) => {
+  const filter = config.urlFilter || config.url;
+  if (!filter) {
+    return () => true;
+  }
+
+  const tester = createTargetFilter(filter);
+  return t => tester(t.url);
+};
+
+/**
+ * Creates a function to filter a target URL.
+ */
+export const createTargetFilter = (targetUrl: string): ((testUrl: string) => boolean) => {
+  const standardizeMatch = (aUrl: string) => {
+    aUrl = aUrl.toLowerCase();
+
+    const fileUrl = fileUrlToAbsolutePath(aUrl);
+    if (fileUrl) {
+        // Strip file:///, if present
+        aUrl = fileUrl;
+    } else if (isValidUrl(aUrl) && aUrl.includes('://')) {
+        // Strip the protocol, if present
+        aUrl = aUrl.substr(aUrl.indexOf('://') + 3);
+    }
+
+    // Remove optional trailing /
+    if (aUrl.endsWith('/')) {
+      aUrl = aUrl.substr(0, aUrl.length - 1);
+    }
+
+    return aUrl;
+};
+
+  targetUrl = escapeRegexSpecialChars(standardizeMatch(targetUrl), '/*').replace(/\*/g, '.*');
+  const targetUrlRegex = new RegExp('^' + targetUrl + '$', 'g');
+
+  return testUrl => {
+    targetUrlRegex.lastIndex = 0;
+    return targetUrlRegex.test(standardizeMatch(testUrl));
+  };
 };

--- a/src/targets/browser/browserTargets.ts
+++ b/src/targets/browser/browserTargets.ts
@@ -144,11 +144,11 @@ export class BrowserTargetManager implements Disposable {
     });
     cdp.Target.setAutoAttach({ autoAttach: true, waitForDebuggerOnStart: true, flatten: true });
 
-    // For the 'top-level' page, gather telemetry and set the cache state.
-    if (!parentTarget) {
-      cdp.Network.setCacheDisabled({ cacheDisabled: this.launchParams.disableNetworkCache })
-        .catch(err => logger.info(LogTag.RuntimeTarget, 'Error setting network cache state', err));
+    cdp.Network.setCacheDisabled({ cacheDisabled: this.launchParams.disableNetworkCache })
+      .catch(err => logger.info(LogTag.RuntimeTarget, 'Error setting network cache state', err));
 
+    // For the 'top-level' page, gather telemetry.
+    if (!parentTarget) {
       this.retrieveBrowserTelemetry(cdp);
     }
 

--- a/src/targets/browser/browserTargets.ts
+++ b/src/targets/browser/browserTargets.ts
@@ -12,6 +12,10 @@ import { FrameModel } from './frames';
 import { ServiceWorkerModel } from './serviceWorkers';
 import { InlineScriptOffset, ISourcePathResolver } from '../../common/sourcePathResolver';
 import { ScriptSkipper } from '../../adapter/scriptSkipper';
+import { AnyChromeConfiguration } from '../../configuration';
+import { logger } from '../../common/logging/logger';
+import { LogTag } from '../../common/logging';
+import { RawTelemetryReporter } from '../../telemetry/telemetryReporter';
 
 export type PauseOnExceptionsState = 'none' | 'uncaught' | 'all';
 
@@ -30,20 +34,40 @@ export class BrowserTargetManager implements Disposable {
   readonly onTargetAdded = this._onTargetAddedEmitter.event;
   readonly onTargetRemoved = this._onTargetRemovedEmitter.event;
 
-  static async connect(connection: CdpConnection, sourcePathResolver: ISourcePathResolver, targetOrigin: any): Promise<BrowserTargetManager | undefined> {
+  static async connect(
+    connection: CdpConnection,
+    sourcePathResolver: ISourcePathResolver,
+    launchParams: AnyChromeConfiguration,
+    telemetry: RawTelemetryReporter,
+    targetOrigin: any,
+  ): Promise<BrowserTargetManager | undefined> {
     const rootSession = connection.rootSession();
     const result = await rootSession.Target.attachToBrowserTarget({});
     if (!result)
       return;
     const browserSession = connection.createSession(result.sessionId);
-    return new BrowserTargetManager(connection, browserSession, sourcePathResolver, targetOrigin);
+    return new BrowserTargetManager(
+      connection,
+      browserSession,
+      sourcePathResolver,
+      telemetry,
+      launchParams,
+      targetOrigin,
+    );
   }
 
   setSkipFiles(scriptSkipper: ScriptSkipper) {
     this._scriptSkipper = scriptSkipper;
   }
 
-  constructor(connection: CdpConnection, browserSession: Cdp.Api, sourcePathResolver: ISourcePathResolver, targetOrigin: any) {
+  constructor(
+    connection: CdpConnection,
+    browserSession: Cdp.Api,
+    sourcePathResolver: ISourcePathResolver,
+    private readonly telemetry: RawTelemetryReporter,
+    private readonly launchParams: AnyChromeConfiguration,
+    targetOrigin: any,
+  ) {
     this._connection = connection;
     this._sourcePathResolver = sourcePathResolver;
     this._browser = browserSession;
@@ -71,26 +95,35 @@ export class BrowserTargetManager implements Disposable {
     await this._browser.Browser.close({});
   }
 
-  waitForMainTarget(): Promise<BrowserTarget | undefined> {
+  waitForMainTarget(filter?: (target: Cdp.Target.TargetInfo) => boolean): Promise<BrowserTarget | undefined> {
     let callback: (result: BrowserTarget | undefined) => void;
     const promise = new Promise<BrowserTarget | undefined>(f => callback = f);
-    this._browser.Target.setDiscoverTargets({ discover: true });
-    this._browser.Target.on('targetCreated', async event => {
-      if (this._targets.size)
+    const attemptAttach = async ({ targetInfo }: {targetInfo: Cdp.Target.TargetInfo}) => {
+      if (this._targets.size) {
         return;
-      const targetInfo = event.targetInfo;
-      if (targetInfo.type !== 'page')
+      }
+      if (targetInfo.type !== 'page') {
         return;
+      }
+      if (filter && !filter(targetInfo)) {
+        return;
+      }
+
       const response = await this._browser.Target.attachToTarget({ targetId: targetInfo.targetId, flatten: true });
       if (!response) {
         callback(undefined);
         return;
       }
       callback(this._attachedToTarget(targetInfo, response.sessionId, true));
-    });
+    };
+
+    this._browser.Target.setDiscoverTargets({ discover: true });
+    this._browser.Target.on('targetCreated', attemptAttach); // new page
+    this._browser.Target.on('targetInfoChanged', attemptAttach); // nav on existing page
     this._browser.Target.on('detachedFromTarget', event => {
       this._detachedFromTarget(event.targetId!);
     });
+
     return promise;
   }
 
@@ -111,6 +144,14 @@ export class BrowserTargetManager implements Disposable {
     });
     cdp.Target.setAutoAttach({ autoAttach: true, waitForDebuggerOnStart: true, flatten: true });
 
+    // For the 'top-level' page, gather telemetry and set the cache state.
+    if (!parentTarget) {
+      cdp.Network.setCacheDisabled({ cacheDisabled: this.launchParams.disableNetworkCache })
+        .catch(err => logger.info(LogTag.RuntimeTarget, 'Error setting network cache state', err));
+
+      this.retrieveBrowserTelemetry(cdp);
+    }
+
     if (domDebuggerTypes.has(targetInfo.type))
       this.frameModel.attached(cdp, targetInfo.targetId);
     this.serviceWorkerModel.attached(cdp);
@@ -122,6 +163,59 @@ export class BrowserTargetManager implements Disposable {
       cdp.Runtime.runIfWaitingForDebugger({});
 
     return target;
+  }
+
+  private async retrieveBrowserTelemetry(cdp: Cdp.Api) {
+    try {
+      const info = await cdp.Browser.getVersion({});
+      if (!info) {
+        throw new Error('Undefined return from getVersion()');
+      }
+
+      const properties = {
+        'Versions.Target.CRDPVersion': info.protocolVersion,
+        'Versions.Target.Revision': info.revision,
+        'Versions.Target.UserAgent': info.userAgent,
+        'Versions.Target.V8': info.jsVersion,
+        'Versions.Target.Version': '',
+        'Versions.Target.Project': '',
+        'Versions.Target.Product': '',
+      };
+
+      logger.verbose(LogTag.RuntimeTarget, 'Retrieved browser information', info);
+
+      const parts = (info.product || '').split('/');
+      if (parts.length === 2) { // Currently response.product looks like "Chrome/65.0.3325.162" so we split the project and the actual version number
+        properties['Versions.Target.Project'] =  parts[0];
+        properties['Versions.Target.Version'] =  parts[1];
+      } else { // If for any reason that changes, we submit the entire product as-is
+        properties['Versions.Target.Product'] = info.product;
+      }
+
+      /* __GDPR__FRAGMENT__
+        "VersionInformation" : {
+          "Versions.Target.CRDPVersion" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+          "Versions.Target.Revision" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+          "Versions.Target.UserAgent" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+          "Versions.Target.V8" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+          "Versions.Target.V<NUMBER>" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+          "Versions.Target.Project" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+          "Versions.Target.Version" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+          "Versions.Target.Product" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+          "Versions.Target.NoUserAgentReason" : { "classification": "SystemMetaData", "purpose": "FeatureInsight" },
+          "${include}": [ "${IExecutionResultTelemetryProperties}" ]
+        }
+      */
+      /* __GDPR__
+        "target-version" : {
+          "${include}": [ "${DebugCommonProperties}" ]
+        }
+      */
+
+      this.telemetry.report('target-version', properties);
+    } catch (e) {
+      logger.warn(LogTag.RuntimeTarget, 'Error getting browser telemetry', e);
+    }
   }
 
   async _detachedFromTarget(targetId: string) {

--- a/src/telemetry/telemetryReporter.ts
+++ b/src/telemetry/telemetryReporter.ts
@@ -38,6 +38,10 @@ export class TelemetryReporter {
     this.reportOutcome(receivedTime, dapCommand, {}, RequestOutcome.Succesful);
   }
 
+  reportEvent(event: string, data?: any) {
+    this._strategy.report(`${this._strategy.eventsPrefix}/${event}`, data);
+  }
+
   private reportOutcome(receivedTime: [number, number], dapCommand: string, properties: TelemetryEntityProperties, outcome: RequestOutcome) {
     const elapsedTime = calculateElapsedTime(receivedTime);
     const entityProperties = { ...properties, time: this._strategy.adjustElapsedTime(elapsedTime), succesful: outcome === RequestOutcome.Succesful };

--- a/src/test/common/urlUtils.test.ts
+++ b/src/test/common/urlUtils.test.ts
@@ -1,11 +1,11 @@
 import { expect } from 'chai';
 import { stub } from 'sinon';
 import * as os from 'os';
-import { fileUrlToAbsolutePath } from '../../common/urlUtils';
+import { fileUrlToAbsolutePath, createTargetFilter } from '../../common/urlUtils';
 
 describe('urlUtils', () => {
   describe('fileUrlToPath()', () => {
-it('removes file:///', () => {
+    it('removes file:///', () => {
       expect(fileUrlToAbsolutePath('file:///c:/file.js')).to.equal('c:\\file.js');
     });
 
@@ -37,6 +37,88 @@ it('removes file:///', () => {
       // Should remove query args?
       const expectedPath = '/Users/me/file?config={"a":"b"}';
       expect(fileUrlToAbsolutePath('file://' + expectedPath)).to.equal(expectedPath);
+    });
+  });
+
+  describe('createTargetFilter()', () => {
+    function testAll(filter: string, cases: [string, boolean][]) {
+      const filterFn = createTargetFilter(filter);
+      for (const [url, expected] of cases) {
+        expect(filterFn(url)).to.equal(
+          expected,
+          `expected ${url} to ${expected ? '' : 'not '}match ${filter}`,
+        );
+      }
+    }
+
+    it('returns exact match', () => {
+      testAll('http://localhost/site', [
+        ['http://localhost/site/page', false],
+        ['http://localhost/site', true],
+      ]);
+    });
+
+    it('ignores the url protocol', () => {
+      testAll('https://localhost', [['https://outlook.com', false], ['http://localhost', true]]);
+    });
+
+    it('really ignores the url protocol', () => {
+      testAll('localhost', [['https://outlook.com', false], ['http://localhost', true]]);
+    });
+
+    it('is case-insensitive', () => {
+      testAll('http://LOCALHOST', [['http://localhost/site', false], ['http://localhost', true]]);
+    });
+
+    it('does not return substring fuzzy match as in pre 0.1.9', () => {
+      testAll('http://localhost/site/page', [['http://localhost/site', false]]);
+    });
+
+    it('respects one wildcard', () => {
+      testAll('localhost/site/*', [
+        ['http://localhost/site/app', true],
+        ['http://localhost/site/', false],
+        ['http://localhost/', false],
+      ]);
+    });
+
+    it('respects wildcards with query params', () => {
+      testAll('localhost:3000/site/?*', [
+        ['http://localhost:3000/site/?blah=1', true],
+        ['http://localhost:3000/site/?blah=2', true],
+        ['http://localhost:3000/site/', false],
+      ]);
+    });
+
+    it('works with special chars', () => {
+      testAll('http://localhost(foo)/[bar]/?baz', [
+        ['http://localhost(foo)/[bar]/?baz', true],
+        ['http://localhost(foo)/bar/?words', false],
+        ['http://localhost/[bar]/?(somethingelse)', false],
+      ]);
+    });
+
+    it('works with special chars + wildcard', () => {
+      testAll('http://localhost/[bar]/?(*)', [
+        ['http://localhost/[bar]/?(words)', true],
+        ['http://localhost/bar/?words', false],
+        ['http://localhost/[bar]/?(somethingelse)', true],
+      ]);
+    });
+
+    it('matches an ending slash', () => {
+      testAll('http://localhost', [['http://localhost/', true], ['http://localhost', true]]);
+    });
+
+    it('works with file://', () => {
+      testAll('/foo/bar', [['file:///foo/bar', true], ['http://localhost', false]]);
+    });
+
+    it('works with file:// + query params', () => {
+      testAll('/foo/bar?a://*', [
+        ['file:///foo/bar?a%3A%2F%2Fb', true],
+        ['http://localhost', false],
+      ]);
     });
   });
 });

--- a/src/test/testRunner.ts
+++ b/src/test/testRunner.ts
@@ -32,6 +32,7 @@ export async function run(): Promise<void> {
 
   const runner = new Mocha({
     timeout: 2000000,
+    grep: 'createTargetFilter',
     ...JSON.parse(process.env.PWA_TEST_OPTIONS || '{}'),
   });
 

--- a/src/ui/sessionManager.ts
+++ b/src/ui/sessionManager.ts
@@ -83,7 +83,11 @@ export class SessionManager implements vscode.DebugAdapterDescriptorFactory, Dis
     const session = new Session(debugSession);
     if (debugSession.configuration['__pendingTargetId']) {
       const pendingTargetId = debugSession.configuration['__pendingTargetId'] as string;
-      const target = this._pendingTarget.get(pendingTargetId)!;
+      const target = this._pendingTarget.get(pendingTargetId);
+      if (!target) {
+        return; // can happen due to various races when navigating
+      }
+
       this._pendingTarget.delete(pendingTargetId);
       session.listenToTarget(target); 
       const callbacks = this._sessionForTargetCallbacks.get(target);

--- a/src/ui/sessionManager.ts
+++ b/src/ui/sessionManager.ts
@@ -87,11 +87,7 @@ export class SessionManager implements vscode.DebugAdapterDescriptorFactory, Dis
     const session = new Session(debugSession);
     if (debugSession.configuration['__pendingTargetId']) {
       const pendingTargetId = debugSession.configuration['__pendingTargetId'] as string;
-      const target = this._pendingTarget.get(pendingTargetId);
-      if (!target) {
-        return; // can happen due to various races when navigating
-      }
-
+      const target = this._pendingTarget.get(pendingTargetId)!;
       this._pendingTarget.delete(pendingTargetId);
       session.listenToTarget(target); 
       const callbacks = this._sessionForTargetCallbacks.get(target);


### PR DESCRIPTION
This Adds filtering by `url`/`urlFilter` to the browser attacher --
previously it'd always connect to the first tab/target, which is not
always desirable if the user has several tabs open.

We also now support timeouts in the browser attacher and launcher,
set the network cache setting on the target page, and send and log
telemetry about the attached page, like the previous debug adapter did.