### PR TITLE
feat: support opening an HTML page

### DIFF
--- a/demos/simple-html/index.html
+++ b/demos/simple-html/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <title>Document</title>
+</head>
+  <h1></h1>
+<body>
+  <script>
+    const title = document.querySelector('h1');
+    title.innerHTML = 'Hello world!';
+  </script>
+</body>
+</html>

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -610,7 +610,12 @@ function buildDebuggers() {
     let entry = output.find(o => o.type === d.type);
     if (!entry) {
       const { request, configurationAttributes, required, ...rest } = d;
-      entry = { ...rest, configurationAttributes: {}, configurationSnippets: [] };
+      entry = {
+        ...rest,
+        languages: ['javascript', 'typescript', 'javascriptreact', 'typescriptreact'],
+        configurationAttributes: {},
+        configurationSnippets: [],
+      };
       output.push(entry);
     }
 

--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -58,7 +58,7 @@ const strings = {
     "Configures a web server to start up. Takes the same configuration as the 'node' launch task.",
   'chrome.userDataDir.description':
     'By default, Chrome is launched with a separate user profile in a temp folder. Use this option to override it. Set to false to launch with your default user profile.',
-  'chrome.label': 'Debug your JavaScript code in the Chrome browser, or any other target that supports the Chrome Debugger protocol.',
+  'chrome.label': 'NAMESPACE(Chrome)',
   'chrome.launch.label': 'Chrome: Launch',
   'chrome.launch.description': 'Launch Chrome to debug a URL',
   'chrome.attach.label': 'Chrome: Attach',
@@ -74,7 +74,7 @@ const strings = {
   'node.console.title': 'Node Debug Console',
   'node.disableOptimisticBPs.description':
     "Don't set breakpoints in any file until a sourcemap has been loaded for that file.",
-  'node.label': 'Node.js',
+  'node.label': 'NAMESPACE(Node.js)',
   'node.launch.autoAttachChildProcesses.description':
     'Attach debugger to new child processes automatically.',
   'node.launch.config.name': 'Launch',

--- a/src/nodeDebugConfigurationProvider.ts
+++ b/src/nodeDebugConfigurationProvider.ts
@@ -36,16 +36,20 @@ type ResolvingNodeConfiguration =
  * close to 1:1 drop-in, this is nearly identical to the original vscode-
  * node-debug, with support for some legacy options (mern, useWSL) removed.
  */
-export class NodeDebugConfigurationProvider
-  extends BaseConfigurationProvider<AnyNodeConfiguration>
+export class NodeDebugConfigurationProvider extends BaseConfigurationProvider<AnyNodeConfiguration>
   implements vscode.DebugConfigurationProvider {
   constructor(
     context: vscode.ExtensionContext,
     private readonly nvmResolver: INvmResolver = new NvmResolver(),
   ) {
     super(context);
+
+    this.setProvideDefaultConfiguration(folder => createLaunchConfigFromContext(folder, true));
   }
 
+  /**
+   * @override
+   */
   protected async resolveDebugConfigurationAsync(
     folder: vscode.WorkspaceFolder | undefined,
     config: ResolvingNodeConfiguration,

--- a/src/targets/browser/browserLauncher.ts
+++ b/src/targets/browser/browserLauncher.ts
@@ -17,6 +17,7 @@ import { Contributions } from '../../common/contributionUtils';
 import { EnvironmentVars } from '../../common/environmentVars';
 import { ScriptSkipper } from '../../adapter/scriptSkipper';
 import { RawTelemetryReporterToDap, RawTelemetryReporter } from '../../telemetry/telemetryReporter';
+import { absolutePathToFileUrl } from '../../common/urlUtils';
 
 const localize = nls.loadMessageBundle();
 
@@ -141,9 +142,18 @@ export class BrowserLauncher implements Launcher {
     return this._mainTarget;
   }
 
-  async finishLaunch(mainTarget: BrowserTarget): Promise<void> {
-    if (this._launchParams!.url && !(this._launchParams as any)['skipNavigateForTest'])
-      await mainTarget.cdp().Page.navigate({ url: this._launchParams!.url });
+  private async finishLaunch(mainTarget: BrowserTarget, params: AnyChromeConfiguration): Promise<void> {
+    if ('skipNavigateForTest' in params) {
+      return;
+    }
+
+    const url = 'file' in params && params.file
+      ? absolutePathToFileUrl(path.resolve(params.webRoot || params.rootPath || '', params.file))
+      : params.url;
+
+    if (url) {
+      await mainTarget.cdp().Page.navigate({ url });
+    }
   }
 
   async launch(params: AnyChromeConfiguration, targetOrigin: any, telemetryReporter: RawTelemetryReporterToDap): Promise<LaunchResult> {
@@ -154,7 +164,7 @@ export class BrowserLauncher implements Launcher {
     const targetOrError = await this.prepareLaunch(params, targetOrigin, telemetryReporter);
     if (typeof targetOrError === 'string')
       return { error: targetOrError };
-    await this.finishLaunch(targetOrError);
+    await this.finishLaunch(targetOrError, params);
     return { blockSessionTermination: true };
   }
 


### PR DESCRIPTION
This adds support for the "file" option in Chrome's launch.json to open
and HTML page. Support for this was straightforward. I also did some
work on the config providers to make HTML pages F5-able without needing
a preexisting launch configuration.

![Kapture 2019-11-07 at 11 56 23](https://user-images.githubusercontent.com/2230985/68422786-b0e70700-0155-11ea-9a01-87291bcb98bc.gif)

There's an outstanding issue where breakpoints set before Chrome is launch are _sent_ to Chrome, but don't seem to apply. Pinged Dmitry for ideas on this, seems like some kind of race. https://github.com/microsoft/vscode-pwa/issues/79