### PR TITLE
Fix telemetry properties

### DIFF
--- a/src/telemetry/telemetryReporter.ts
+++ b/src/telemetry/telemetryReporter.ts
@@ -98,7 +98,7 @@ export class RawTelemetryReporterToDap implements RawTelemetryReporter {
     this._dap.output({
       category: 'telemetry',
       output: entityName,
-      data: JSON.stringify(entityProperties)
+      data: entityProperties
     });
   };
 }


### PR DESCRIPTION
Telemetry properties were being ignored because we shouldn't convert data into a string