### PR TITLE
feat: better timeouts, cancellation tokens

### DIFF
--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -157,6 +157,8 @@ const strings = {
     'An array of glob patterns for files to skip when debugging. The pattern `<node_internals>/**` matches all internal Node.js modules.',
   'smartStep.description':
     'Automatically step through generated code that cannot be mapped back to the original source.',
+
+  'errors.timeout': '{0}: timeout after {1}ms',
 };
 
 export default strings;

--- a/src/common/cancellation.ts
+++ b/src/common/cancellation.ts
@@ -1,0 +1,158 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { CancellationToken } from 'vscode';
+import { EventEmitter, Event } from './events';
+import { IDisposable } from './disposable';
+
+/**
+ * Thrown from `cancellableRace` if cancellation is requested.
+ */
+export class TaskCancelledError extends Error {}
+
+/**
+ * Returns the result of the promise if it resolves before the cancellation
+ * is requested. Otherwise, throws a TaskCancelledError.
+ */
+export function cancellableRace<T>(
+  promise: Promise<T>,
+  cancellation: CancellationToken,
+  message?: string,
+): Promise<T> {
+  if (cancellation.isCancellationRequested) {
+    return Promise.reject(new TaskCancelledError(message || 'Task cancelled'));
+  }
+
+  let didTimeout: () => void;
+  const cancellationPromise = new Promise<void>(resolve => (didTimeout = resolve));
+  const disposable = cancellation.onCancellationRequested(didTimeout!);
+
+  return Promise.race([
+    cancellationPromise.then(() => {
+      throw new TaskCancelledError(message || 'Task cancelled');
+    }),
+    promise.finally(() => disposable.dispose()),
+  ]);
+}
+
+const shortcutEvent = Object.freeze(function(callback, context?): IDisposable {
+  const handle = setTimeout(callback.bind(context), 0);
+  return {
+    dispose() {
+      clearTimeout(handle);
+    },
+  };
+} as Event<any>);
+
+export const NeverCancelled: CancellationToken = Object.freeze({
+  isCancellationRequested: false,
+  onCancellationRequested: () => ({ dispose: () => undefined }),
+});
+
+export const Cancelled: CancellationToken = Object.freeze({
+  isCancellationRequested: true,
+  onCancellationRequested: shortcutEvent,
+});
+
+/**
+ * A cancellation source creates and controls a [cancellation token](#CancellationToken).
+ * Mirrored here because the debugger internals can't depend on concrete types
+ * from `vscode`.
+ */
+export class CancellationTokenSource {
+  private _token?: CancellationToken = undefined;
+  private _parentListener?: IDisposable = undefined;
+
+  constructor(parent?: CancellationToken) {
+    this._parentListener = parent && parent.onCancellationRequested(this.cancel, this);
+  }
+
+  /**
+   * Returns a cancellation token source that times out after the given duration.
+   */
+  public static withTimeout(timeout: number, parent?: CancellationToken) {
+    const cts = new CancellationTokenSource(parent);
+    const token = (cts._token = new MutableToken());
+
+    let timer = setTimeout(() => token.cancel(), timeout);
+    token.onCancellationRequested(() => clearTimeout(timer));
+
+    return cts;
+  }
+
+  get token(): CancellationToken {
+    if (!this._token) {
+      // be lazy and create the token only when
+      // actually needed
+      this._token = new MutableToken();
+    }
+    return this._token;
+  }
+
+  cancel(): void {
+    if (!this._token) {
+      // save an object by returning the default
+      // cancelled token when cancellation happens
+      // before someone asks for the token
+      this._token = Cancelled;
+    } else if (this._token instanceof MutableToken) {
+      // actually cancel
+      this._token.cancel();
+    }
+  }
+
+  dispose(cancel: boolean = false): void {
+    if (cancel) {
+      this.cancel();
+    }
+    if (this._parentListener) {
+      this._parentListener.dispose();
+    }
+    if (!this._token) {
+      // ensure to initialize with an empty token if we had none
+      this._token = NeverCancelled;
+    } else if (this._token instanceof MutableToken) {
+      // actually dispose
+      this._token.dispose();
+    }
+  }
+}
+
+class MutableToken implements CancellationToken {
+  private _isCancelled: boolean = false;
+  private _emitter: EventEmitter<any> | null = null;
+
+  constructor() {}
+
+  public cancel() {
+    if (!this._isCancelled) {
+      this._isCancelled = true;
+      if (this._emitter) {
+        this._emitter.fire(undefined);
+        this.dispose();
+      }
+    }
+  }
+
+  get isCancellationRequested(): boolean {
+    return this._isCancelled;
+  }
+
+  get onCancellationRequested(): Event<any> {
+    if (this._isCancelled) {
+      return shortcutEvent;
+    }
+    if (!this._emitter) {
+      this._emitter = new EventEmitter<any>();
+    }
+    return this._emitter.event;
+  }
+
+  public dispose(): void {
+    if (this._emitter) {
+      this._emitter.dispose();
+      this._emitter = null;
+    }
+  }
+}

--- a/src/common/logging/index.ts
+++ b/src/common/logging/index.ts
@@ -21,6 +21,7 @@ export const enum LogLevel {
 
 export enum LogTag {
   Runtime = 'runtime',
+  RuntimeLaunch = 'runtime.launch',
   RuntimeTarget = 'runtime.target',
   RuntimeWelcome = 'runtime.welcome',
   RuntimeException = 'runtime.exception',

--- a/src/targets/browser/launcher.ts
+++ b/src/targets/browser/launcher.ts
@@ -11,6 +11,9 @@ import { PipeTransport, WebSocketTransport } from '../../cdp/transport';
 import { Readable, Writable } from 'stream';
 import { EnvironmentVars } from '../../common/environmentVars';
 import { RawTelemetryReporterToDap, RawTelemetryReporter } from '../../telemetry/telemetryReporter';
+import { CancellationToken } from 'vscode';
+import { TaskCancelledError } from '../../common/cancellation';
+import { IDisposable } from '../../common/disposable';
 
 const DEFAULT_ARGS = [
   '--disable-background-networking',
@@ -34,13 +37,13 @@ interface LaunchOptions {
   env?: EnvironmentVars;
   ignoreDefaultArgs?: boolean;
   connection?: 'pipe' | number; // pipe or port number
-  timeout?: number;
   userDataDir?: string;
 }
 
 export async function launch(
   executablePath: string,
   rawTelemetryReporter: RawTelemetryReporter,
+  cancellationToken: CancellationToken,
   options: LaunchOptions | undefined = {},
 ): Promise<CdpConnection> {
   const {
@@ -50,7 +53,6 @@ export async function launch(
     env = EnvironmentVars.empty,
     ignoreDefaultArgs = false,
     connection = 'pipe',
-    timeout = 30000,
   } = options;
 
   const browserArguments: string[] = [];
@@ -96,8 +98,8 @@ export async function launch(
   process.on('exit', killBrowser);
   try {
     if (!usePipe) {
-      const browserWSEndpoint = await waitForWSEndpoint(browserProcess, timeout);
-      const transport = await WebSocketTransport.create(browserWSEndpoint);
+      const browserWSEndpoint = await waitForWSEndpoint(browserProcess, cancellationToken);
+      const transport = await WebSocketTransport.create(browserWSEndpoint, cancellationToken);
       return new CdpConnection(transport, rawTelemetryReporter);
     } else {
       const stdio = (browserProcess.stdio as unknown) as [
@@ -147,16 +149,17 @@ interface AttachOptions {
 
 export async function attach(
   options: AttachOptions,
+  cancellationToken: CancellationToken,
   rawTelemetryReporter: RawTelemetryReporterToDap,
 ): Promise<CdpConnection> {
   const { browserWSEndpoint, browserURL } = options;
 
   if (browserWSEndpoint) {
-    const connectionTransport = await WebSocketTransport.create(browserWSEndpoint);
+    const connectionTransport = await WebSocketTransport.create(browserWSEndpoint, cancellationToken);
     return new CdpConnection(connectionTransport, rawTelemetryReporter);
   } else if (browserURL) {
-    const connectionURL = await getWSEndpoint(browserURL);
-    const connectionTransport = await WebSocketTransport.create(connectionURL);
+    const connectionURL = await getWSEndpoint(browserURL, cancellationToken);
+    const connectionTransport = await WebSocketTransport.create(connectionURL, cancellationToken);
     return new CdpConnection(connectionTransport, rawTelemetryReporter);
   }
   throw new Error('Either browserURL or browserWSEndpoint needs to be specified');
@@ -164,7 +167,7 @@ export async function attach(
 
 function waitForWSEndpoint(
   browserProcess: childProcess.ChildProcess,
-  timeout: number,
+  cancellationToken: CancellationToken,
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const rl = readline.createInterface({ input: browserProcess.stderr! });
@@ -178,7 +181,10 @@ function waitForWSEndpoint(
     browserProcess.on('exit', onExit);
     browserProcess.on('error', onError);
 
-    const timeoutId = timeout ? setTimeout(onTimeout, timeout) : 0;
+    const timeout = cancellationToken.onCancellationRequested(() => {
+      cleanup();
+      reject(new Error(`Timed out after ${timeout} ms while trying to connect to the browser!`));
+    });
 
     function onDone(error?: Error) {
       cleanup();
@@ -195,11 +201,6 @@ function waitForWSEndpoint(
       );
     }
 
-    function onTimeout() {
-      cleanup();
-      reject(new Error(`Timed out after ${timeout} ms while trying to connect to the browser!`));
-    }
-
     function onLine(line: string) {
       stderr += line + '\n';
       const match = line.match(/^DevTools listening on (ws:\/\/.*)$/);
@@ -209,7 +210,7 @@ function waitForWSEndpoint(
     }
 
     function cleanup() {
-      if (timeoutId) clearTimeout(timeoutId);
+      timeout.dispose();
       rl.removeListener('line', onLine);
       rl.removeListener('close', onClose);
       browserProcess.removeListener('exit', onExit);
@@ -218,9 +219,13 @@ function waitForWSEndpoint(
   });
 }
 
-export async function getWSEndpoint(browserURL: string): Promise<string> {
+export async function getWSEndpoint(
+  browserURL: string,
+  cancellationToken: CancellationToken,
+): Promise<string> {
   const jsonVersion = await fetchJson<{ webSocketDebuggerUrl?: string }>(
     URL.resolve(browserURL, '/json/version'),
+    cancellationToken,
   );
   if (jsonVersion.webSocketDebuggerUrl) {
     return jsonVersion.webSocketDebuggerUrl;
@@ -230,6 +235,7 @@ export async function getWSEndpoint(browserURL: string): Promise<string> {
   // Request both and return whichever one got us a string.
   const jsonList = await fetchJson<{ webSocketDebuggerUrl: string }[]>(
     URL.resolve(browserURL, '/json/list'),
+    cancellationToken,
   );
   if (jsonList.length) {
     return jsonList[0].webSocketDebuggerUrl;
@@ -238,17 +244,20 @@ export async function getWSEndpoint(browserURL: string): Promise<string> {
   throw new Error('Could not find any debuggable target');
 }
 
-async function fetchJson<T>(url: string): Promise<T> {
-  return new Promise((resolve, reject) => {
+async function fetchJson<T>(url: string, cancellationToken: CancellationToken): Promise<T> {
+  const disposables: IDisposable[] = [];
+
+  return new Promise<T>((resolve, reject) => {
     const protocolRequest = url.startsWith('https')
       ? https.request.bind(https)
       : http.request.bind(http);
-    const requestOptions = Object.assign(URL.parse(url), { method: 'GET' });
-    const request = protocolRequest(requestOptions, (res: http.IncomingMessage) => {
+
+    const request = protocolRequest(url, res => {
+      disposables.push(cancellationToken.onCancellationRequested(() => res.destroy()));
+
       let data = '';
       if (res.statusCode !== 200) {
-        // Consume response data to free up memory.
-        res.resume();
+        res.resume(); // Consume response data to free up memory.
         reject(new Error('HTTP ' + res.statusCode));
         return;
       }
@@ -258,7 +267,14 @@ async function fetchJson<T>(url: string): Promise<T> {
       res.on('end', () => resolve(JSON.parse(data)));
     });
 
-    request.on('error', reject!);
+    disposables.push(
+      cancellationToken.onCancellationRequested(() => {
+        request.destroy();
+        reject(new TaskCancelledError(`Cancelled GET ${url}`));
+      }),
+    );
+
+    request.on('error', reject);
     request.end();
-  });
+  }).finally(() => disposables.forEach(d => d.dispose()));
 }

--- a/src/targets/node/nodeAttacher.ts
+++ b/src/targets/node/nodeAttacher.ts
@@ -47,7 +47,10 @@ export class NodeAttacher extends NodeLauncherBase<INodeAttachConfiguration> {
     const wd = spawnWatchdog(findInPath('node', process.env) || 'node', {
       ipcAddress: runData.serverAddress,
       scriptName: 'Remote Process',
-      inspectorURL: await getWSEndpoint(`http://${runData.params.address}:${runData.params.port}`),
+      inspectorURL: await getWSEndpoint(
+        `http://${runData.params.address}:${runData.params.port}`,
+        runData.context.cancellationToken,
+      ),
       waitForDebugger: true,
       dynamicAttach: true,
     });

--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -128,8 +128,8 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
       }),
     });
 
-    await this.launchProgram(run);
-    return { blockSessionTermination: true };
+    const error = await this.launchProgram(run);
+    return error ? { error } : { blockSessionTermination: true };
   }
 
   /**
@@ -185,7 +185,7 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
   /**
    * Launches the program. Called after the server is running and upon restart.
    */
-  protected abstract launchProgram(runData: IRunData<T>): Promise<void>;
+  protected abstract launchProgram(runData: IRunData<T>): Promise<string | void>;
 
   /**
    * Method that should be called when the program from launchProgram() exits.

--- a/src/targets/node/watchdog.ts
+++ b/src/targets/node/watchdog.ts
@@ -4,6 +4,7 @@
 import * as net from 'net';
 import { WebSocketTransport, PipeTransport } from '../../cdp/transport';
 import { IWatchdogInfo } from './watchdogSpawn';
+import { NeverCancelled } from '../../common/cancellation';
 
 const info: IWatchdogInfo = JSON.parse(process.env.NODE_INSPECTOR_INFO!);
 
@@ -56,7 +57,7 @@ process.on('exit', () => {
         target.close();
         target = undefined;
       }
-      target = await WebSocketTransport.create(info.inspectorURL);
+      target = await WebSocketTransport.create(info.inspectorURL, NeverCancelled);
       target.onmessage = data => server.send(data);
       target.onclose = () => {
         if (target)

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -8,6 +8,7 @@ import { AnyLaunchConfiguration } from '../configuration';
 import { ScriptSkipper } from '../adapter/scriptSkipper';
 import Dap from '../dap/api';
 import { RawTelemetryReporterToDap } from '../telemetry/telemetryReporter';
+import { CancellationToken } from 'vscode';
 
 /**
  * A generic running process that can be debugged. We may have a target before
@@ -50,6 +51,7 @@ export interface Target {
 
 export interface ILaunchContext {
   dap: Dap.Api;
+  cancellationToken: CancellationToken;
   targetOrigin: any;
 }
 

--- a/src/test/common/cancellation.test.ts
+++ b/src/test/common/cancellation.test.ts
@@ -1,0 +1,163 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import * as assert from 'assert';
+import { expect } from 'chai';
+import {
+  CancellationTokenSource,
+  NeverCancelled,
+  cancellableRace,
+  Cancelled,
+  TaskCancelledError,
+} from '../../common/cancellation';
+import { delay } from '../../common/promiseUtil';
+
+describe('CancellationToken', () => {
+  it('None', () => {
+    expect(NeverCancelled.isCancellationRequested).to.equal(false);
+    expect(typeof NeverCancelled.onCancellationRequested).to.equal('function');
+  });
+
+  it('cancel before token', function(done) {
+    const source = new CancellationTokenSource();
+    expect(source.token.isCancellationRequested).to.equal(false);
+    source.cancel();
+
+    expect(source.token.isCancellationRequested).to.equal(true);
+
+    source.token.onCancellationRequested(() => {
+      assert.ok(true);
+      done();
+    });
+  });
+
+  it('cancel happens only once', () => {
+    let source = new CancellationTokenSource();
+    expect(source.token.isCancellationRequested).to.equal(false);
+
+    let cancelCount = 0;
+    function onCancel() {
+      cancelCount += 1;
+    }
+
+    source.token.onCancellationRequested(onCancel);
+
+    source.cancel();
+    source.cancel();
+
+    expect(cancelCount).to.equal(1);
+  });
+
+  it('cancel calls all listeners', () => {
+    let count = 0;
+
+    let source = new CancellationTokenSource();
+    source.token.onCancellationRequested(() => {
+      count += 1;
+    });
+    source.token.onCancellationRequested(() => {
+      count += 1;
+    });
+    source.token.onCancellationRequested(() => {
+      count += 1;
+    });
+
+    source.cancel();
+    expect(count).to.equal(3);
+  });
+
+  it('token stays the same', () => {
+    let source = new CancellationTokenSource();
+    let token = source.token;
+    assert.ok(token === source.token); // doesn't change on get
+
+    source.cancel();
+    assert.ok(token === source.token); // doesn't change after cancel
+
+    source.cancel();
+    assert.ok(token === source.token); // doesn't change after 2nd cancel
+
+    source = new CancellationTokenSource();
+    source.cancel();
+    token = source.token;
+    assert.ok(token === source.token); // doesn't change on get
+  });
+
+  it('dispose calls no listeners', () => {
+    let count = 0;
+
+    let source = new CancellationTokenSource();
+    source.token.onCancellationRequested(() => {
+      count += 1;
+    });
+
+    source.dispose();
+    source.cancel();
+    expect(count).to.equal(0);
+  });
+
+  it('dispose calls no listeners (unless told to cancel)', () => {
+    let count = 0;
+
+    let source = new CancellationTokenSource();
+    source.token.onCancellationRequested(() => {
+      count += 1;
+    });
+
+    source.dispose(true);
+    // source.cancel();
+    expect(count).to.equal(1);
+  });
+
+  it('parent cancels child', () => {
+    let parent = new CancellationTokenSource();
+    let child = new CancellationTokenSource(parent.token);
+
+    let count = 0;
+    child.token.onCancellationRequested(() => (count += 1));
+
+    parent.cancel();
+
+    expect(count).to.equal(1);
+    expect(child.token.isCancellationRequested).to.equal(true);
+    expect(parent.token.isCancellationRequested).to.equal(true);
+  });
+
+  describe('cancellableRace', () => {
+    it('returns the value when no cancellation is requested', async () => {
+      const v = await cancellableRace(Promise.resolve(42), NeverCancelled);
+      expect(v).to.equal(42);
+    });
+
+    it('throws if cancellation is requested', async () => {
+      try {
+        await cancellableRace(Promise.resolve(42), Cancelled);
+        throw new Error('expected to throw');
+      } catch (e) {
+        if (e instanceof TaskCancelledError) {
+          expect(e.message).to.equal('Task cancelled');
+        } else {
+          throw e;
+        }
+      }
+    });
+
+    it('throws if lazy cancellation is requested', async () => {
+      try {
+        await cancellableRace(
+          delay(1000),
+          CancellationTokenSource.withTimeout(3).token,
+          'Could not do the thing',
+        );
+        throw new Error('expected to throw');
+      } catch (e) {
+        if (e instanceof TaskCancelledError) {
+          expect(e.message).to.equal('Could not do the thing');
+        } else {
+          throw e;
+        }
+      }
+    });
+  });
+});


### PR DESCRIPTION
Copied the VS Code CancellationTokenSource implementation into here,
since when running in a bespoke debug server (e.g. VS proper) we don't
have access to vscode's concrete types.

Then bubbled it through the launchers and secondary methods. Previously
for instance you could get stuck if you tried to remote attach to a
server that discarded traffic on a port, common in Azure VMs.
Now we show a timeout correctly.

Also fixes some minor error message handling bugs. (Fixes #74)

Timeout options for parity (https://github.com/microsoft/vscode-pwa/issues/26)