### PR TITLE
feat: track vscode lifecycles correctly

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -134,7 +134,7 @@ gulp.task('compile:dynamic', async () => {
 gulp.task('compile:static', () =>
   merge(
     gulp.src(['LICENSE', 'package.json']).pipe(replaceNamespace()),
-    gulp.src('resources/**/*', { base: '.' }),
+    gulp.src(['resources/**/*', 'src/**/*.sh'], { base: '.' }),
   ).pipe(gulp.dest(buildDir)),
 );
 

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -45,14 +45,14 @@ export class Binder implements Disposable {
     this._delegate = delegate;
     this._dap = connection.dap();
     this._targetOrigin = targetOrigin;
-    this._disposables = [this._onTargetListChangedEmitter];
+    this._disposables = [this._onTargetListChangedEmitter, logger];
 
     for (const launcher of launchers) {
       this._launchers.add(launcher);
       launcher.onTargetListChanged(() => {
         const targets = this.targetList();
         this._attachToNewTargets(targets);
-        this._detachOrphaneThreads(targets);
+        this._detachOrphanThreads(targets);
         this._onTargetListChangedEmitter.fire();
       }, undefined, this._disposables);
     }
@@ -88,7 +88,7 @@ export class Binder implements Disposable {
         return {};
       });
       dap.on('restart', async () => {
-        await this._restart(this._rawTelemetryReporter!);
+        await this._restart();
         return {};
       });
     });
@@ -109,8 +109,8 @@ export class Binder implements Disposable {
     return {};
   }
 
-  async _restart(rawTelemetryReporter: RawTelemetryReporterToDap) {
-    await Promise.all([...this._launchers].map(l => l.restart(rawTelemetryReporter)));
+  async _restart() {
+    await Promise.all([...this._launchers].map(l => l.restart()));
   }
 
   async _launch(launcher: Launcher, params: AnyLaunchConfiguration, cancellationToken: CancellationToken): Promise<string | undefined> {
@@ -124,13 +124,13 @@ export class Binder implements Disposable {
     }
 
     ++this._terminationCount;
-    launcher.onTerminated(() => {
+    launcher.onTerminated(result => {
       this._launchers.delete(launcher);
-      this._detachOrphaneThreads(this.targetList());
+      this._detachOrphanThreads(this.targetList(), { restart: result.restart });
       this._onTargetListChangedEmitter.fire();
-      --this._terminationCount;
-      if (!this._terminationCount)
-        this._dap.then(dap => dap.terminated({}));
+      if (!--this._terminationCount) {
+        this._dap.then(dap => dap.terminated({ restart: result.restart }));
+      }
     }, undefined, this._disposables);
   }
 
@@ -178,7 +178,7 @@ export class Binder implements Disposable {
     for (const launcher of this._launchers)
       launcher.dispose();
     this._launchers.clear();
-    this._detachOrphaneThreads([]);
+    this._detachOrphanThreads([]);
   }
 
   targetList(): Target[] {
@@ -224,7 +224,7 @@ export class Binder implements Disposable {
         if (target.canRestart())
           target.restart();
         else
-          await this._restart(this._rawTelemetryReporter!);
+          await this._restart();
         return {};
       });
     }
@@ -236,7 +236,7 @@ export class Binder implements Disposable {
     if (!target.canDetach())
       return;
     await target.detach();
-    this._releaseTarget(target);
+    this._releaseTarget(target,);
   }
 
   _attachToNewTargets(targets: Target[]) {
@@ -249,21 +249,21 @@ export class Binder implements Disposable {
     }
   }
 
-  _detachOrphaneThreads(targets: Target[]) {
+  _detachOrphanThreads(targets: Target[], terminateArgs?: Dap.TerminatedEventParams) {
     const set = new Set(targets);
     for (const target of this._threads.keys()) {
       if (!set.has(target))
-        this._releaseTarget(target);
+        this._releaseTarget(target, terminateArgs);
     }
   }
 
-  _releaseTarget(target: Target) {
+  _releaseTarget(target: Target, terminateArgs: Dap.TerminatedEventParams = {}) {
     const data = this._threads.get(target);
     if (!data)
       return;
     this._threads.delete(target);
     data.thread.dispose();
-    data.debugAdapter.dap.terminated({});
+    data.debugAdapter.dap.terminated(terminateArgs);
     data.debugAdapter.dispose();
     this._delegate.releaseDap(target);
   }

--- a/src/common/logging/fileLogSink.ts
+++ b/src/common/logging/fileLogSink.ts
@@ -19,8 +19,6 @@ const replacer = (_key: string, value: unknown): any => {
   return value;
 };
 
-const writingFiles = new Set<String>();
-
 /**
  * A log sink that writes to a file.
  */
@@ -34,8 +32,7 @@ export class FileLogSink implements ILogSink {
       // already exists
     }
 
-    this.stream = writingFiles.has(file) ? undefined : createWriteStream(file, { flags: 'a' });
-    writingFiles.add(file);
+    this.stream = createWriteStream(file, { flags: 'a' });
   }
 
   /**
@@ -55,7 +52,6 @@ export class FileLogSink implements ILogSink {
     if (this.stream) {
       this.stream.end();
       this.stream = undefined;
-      writingFiles.delete(this.file);
     }
   }
 

--- a/src/common/logging/logger.ts
+++ b/src/common/logging/logger.ts
@@ -155,17 +155,16 @@ export class Logger implements ILogger, Disposable {
       }
     }
 
-    if ('sinks' in this.logTarget) {
-      this.logTarget.sinks.push(...options.sinks);
-      return;
-    }
-
     const prevTarget = this.logTarget;
     this.logTarget = { sinks: options.sinks.slice() };
 
-    // intentionally re-`log()` instead of writing directly to sinks so that
-    // and tag or level filtering is applied.
-    prevTarget.queue.forEach(m => this.log(m));
+    if ('sinks' in prevTarget) {
+      prevTarget.sinks.forEach(s => s.dispose());
+    } else {
+      // intentionally re-`log()` instead of writing directly to sinks so that
+      // and tag or level filtering is applied.
+      prevTarget.queue.forEach(m => this.log(m));
+    }
   }
 }
 

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -146,7 +146,7 @@ export interface IExtensionHostConfiguration extends INodeBaseConfiguration {
   runtimeExecutable: string | null;
 
   /**
-   * Extension host session ID.
+   * Extension host session ID. A "magical" value set by VS Code.
    */
   __sessionId?: string;
 }

--- a/src/dap/custom.d.ts
+++ b/src/dap/custom.d.ts
@@ -1,0 +1,7 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+export interface IRestartParams {
+  port?: number;
+}

--- a/src/dap/custom.d.ts
+++ b/src/dap/custom.d.ts
@@ -1,7 +1,0 @@
-/*---------------------------------------------------------
- * Copyright (C) Microsoft Corporation. All rights reserved.
- *--------------------------------------------------------*/
-
-export interface IRestartParams {
-  port?: number;
-}

--- a/src/targets/node/extensionHostAttacher.ts
+++ b/src/targets/node/extensionHostAttacher.ts
@@ -76,11 +76,11 @@ export class ExtensionHostAttacher extends NodeAttacherBase<IExtensionHostConfig
 
     // Monitor the process ID we read from the telemetry. Once the VS Code
     // process stops, stop our Watchdog, and vise versa.
-    const program = this.program;
-    if (telemetry && program) {
-      const p = new TerminalProcess({ processId: telemetry.processId });
-      p.stopped.then(() => program.stop());
-      program.stopped.then(() => p.stop());
+    const watchdog = this.program;
+    if (telemetry && watchdog) {
+      const code = new TerminalProcess({ processId: telemetry.processId });
+      code.stopped.then(() => watchdog.stop());
+      watchdog.stopped.then(() => code.stop());
     }
 
     return [];

--- a/src/targets/node/extensionHostLauncher.ts
+++ b/src/targets/node/extensionHostLauncher.ts
@@ -7,6 +7,7 @@ import { Contributions } from '../../common/contributionUtils';
 import { NodeLauncherBase, IRunData } from './nodeLauncherBase';
 import { existsSync, lstatSync } from 'fs';
 import { findOpenPort } from '../../common/findOpenPort';
+import { StubProgram } from './program';
 
 /**
  * This interface represents a single command line argument split into a "prefix" and a "path" half.
@@ -38,43 +39,46 @@ export class ExtensionHostLauncher extends NodeLauncherBase<IExtensionHostConfig
   protected async launchProgram(runData: IRunData<IExtensionHostConfiguration>): Promise<void> {
     const port = runData.params.port || (await findOpenPort());
     await (runData.context.dap as any).launchVSCodeRequest({
-      args: this.resolveLaunchArgs(runData.params, port),
+      args: resolveCodeLaunchArgs(runData.params, port),
       env: this.getConfiguredEnvironment(runData.params),
     });
-  }
 
-  protected resolveLaunchArgs(launchArgs: IExtensionHostConfiguration, port: number) {
-    // Separate all "paths" from an arguments into separate attributes.
-    const args = launchArgs.args.map<ILaunchVSCodeArgument>(arg => {
-      if (arg.startsWith('-')) {
-        // arg is an option
-        const pair = arg.split('=', 2);
-        if (pair.length === 2 && (existsSync(pair[1]) || existsSync(pair[1] + '.js'))) {
-          return { prefix: pair[0] + '=', path: pair[1] };
-        }
-        return { prefix: arg };
-      } else {
-        // arg is a path
-        try {
-          const stat = lstatSync(arg);
-          if (stat.isDirectory()) {
-            return { prefix: '--folder-uri=', path: arg };
-          } else if (stat.isFile()) {
-            return { prefix: '--file-uri=', path: arg };
-          }
-        } catch (err) {
-          // file not found
-        }
-        return { path: arg }; // just return the path blindly and hope for the best...
-      }
-    });
-
-    if (!launchArgs.noDebug) {
-      args.unshift({ prefix: `--inspect-brk-extensions=${port}` });
-    }
-
-    args.unshift({ prefix: `--debugId=${launchArgs.__sessionId}` }); // pass the debug session ID so that broadcast events know where they come from
-
-    return args;
+    this.program = new StubProgram();
+    this.program.stop();
   }
 }
+
+export const resolveCodeLaunchArgs = (launchArgs: IExtensionHostConfiguration, port: number) => {
+  // Separate all "paths" from an arguments into separate attributes.
+  const args = launchArgs.args.map<ILaunchVSCodeArgument>(arg => {
+    if (arg.startsWith('-')) {
+      // arg is an option
+      const pair = arg.split('=', 2);
+      if (pair.length === 2 && (existsSync(pair[1]) || existsSync(pair[1] + '.js'))) {
+        return { prefix: pair[0] + '=', path: pair[1] };
+      }
+      return { prefix: arg };
+    } else {
+      // arg is a path
+      try {
+        const stat = lstatSync(arg);
+        if (stat.isDirectory()) {
+          return { prefix: '--folder-uri=', path: arg };
+        } else if (stat.isFile()) {
+          return { prefix: '--file-uri=', path: arg };
+        }
+      } catch (err) {
+        // file not found
+      }
+      return { path: arg }; // just return the path blindly and hope for the best...
+    }
+  });
+
+  if (!launchArgs.noDebug) {
+    args.unshift({ prefix: `--inspect-extensions=${port}` });
+  }
+
+  args.unshift({ prefix: `--debugId=${launchArgs.__sessionId}` }); // pass the debug session ID so that broadcast events know where they come from
+
+  return args;
+};

--- a/src/targets/node/extensionHostLauncher.ts
+++ b/src/targets/node/extensionHostLauncher.ts
@@ -48,7 +48,7 @@ export class ExtensionHostLauncher extends NodeLauncherBase<IExtensionHostConfig
   }
 }
 
-export const resolveCodeLaunchArgs = (launchArgs: IExtensionHostConfiguration, port: number) => {
+const resolveCodeLaunchArgs = (launchArgs: IExtensionHostConfiguration, port: number) => {
   // Separate all "paths" from an arguments into separate attributes.
   const args = launchArgs.args.map<ILaunchVSCodeArgument>(arg => {
     if (arg.startsWith('-')) {

--- a/src/targets/node/killTree.ts
+++ b/src/targets/node/killTree.ts
@@ -22,7 +22,10 @@ export function killTree(processId: number): void {
     // on linux and OS X we kill all direct and indirect child processes as well
     try {
       const cmd = join(__dirname, './terminateProcess.sh');
-      spawnSync(cmd, [processId.toString()]);
+      const r = spawnSync('sh', [cmd, processId.toString()]);
+      if (r.stderr && r.status) {
+        logger.error(LogTag.RuntimeException, 'Error running terminateProcess', r);
+      }
     } catch (err) {
       logger.error(LogTag.RuntimeException, 'Error running terminateProcess', err);
     }

--- a/src/targets/node/nodeAttacher.ts
+++ b/src/targets/node/nodeAttacher.ts
@@ -6,15 +6,15 @@ import { AnyLaunchConfiguration, INodeAttachConfiguration } from '../../configur
 import { Contributions } from '../../common/contributionUtils';
 import { getWSEndpoint } from '../browser/launcher';
 import { spawnWatchdog } from './watchdogSpawn';
-import { NodeLauncherBase, IRunData } from './nodeLauncherBase';
+import { IRunData } from './nodeLauncherBase';
 import { findInPath } from '../../common/pathUtils';
 import { SubprocessProgram } from './program';
 import Cdp from '../../cdp/api';
 import { isLoopback } from '../../common/urlUtils';
-import { INodeTargetLifecycleHooks } from './nodeTarget';
 import { LeaseFile } from './lease-file';
 import { logger } from '../../common/logging/logger';
 import { LogTag } from '../../common/logging';
+import { NodeAttacherBase } from './nodeAttacherBase';
 
 /**
  * Attaches to ongoing Node processes. This works pretty similar to the
@@ -23,14 +23,7 @@ import { LogTag } from '../../common/logging';
  * the debugger, then evaluate and set the environment variables so that
  * child processes operate just like those we boot with the NodeLauncher.
  */
-export class NodeAttacher extends NodeLauncherBase<INodeAttachConfiguration> {
-  /**
-   * Tracker for whether we're waiting to break and instrument into the main
-   * process. This is used to avoid instrumenting unecessarily into subsequent
-   * children.
-   */
-  private capturedEntry = false;
-
+export class NodeAttacher extends NodeAttacherBase<INodeAttachConfiguration> {
   /**
    * @inheritdoc
    */
@@ -61,40 +54,21 @@ export class NodeAttacher extends NodeLauncherBase<INodeAttachConfiguration> {
         this.onProgramTerminated(result);
       }
     });
-
-    this.capturedEntry = false;
   }
 
-  /**
-   * @inheritdoc
-   */
-  protected createLifecycle(
-    cdp: Cdp.Api,
-    run: IRunData<INodeAttachConfiguration>,
-  ): INodeTargetLifecycleHooks {
-    if (this.capturedEntry) {
-      return {};
-    }
-
+  protected async onFirstInitialize(cdp: Cdp.Api, run: IRunData<INodeAttachConfiguration>) {
     // We use a lease file to indicate to the process that the debugger is
     // still running. This is needed because once we attach, we set the
     // NODE_OPTIONS for the process, forever. We can try to unset this on
     // close, but this isn't reliable as it's always possible
     const leaseFile = new LeaseFile();
 
-    this.capturedEntry = true;
+    await Promise.all([
+      this.gatherTelemetry(cdp, run),
+      this.setEnvironmentVariables(cdp, run, leaseFile.path),
+    ]);
 
-    return {
-      initialized: async () => {
-        await Promise.all([
-          this.gatherTelemetry(cdp),
-          this.setEnvironmentVariables(cdp, run, leaseFile.path),
-        ]);
-      },
-      close: async () => {
-        leaseFile.dispose();
-      },
-    };
+    return [leaseFile];
   }
 
   private async setEnvironmentVariables(
@@ -107,7 +81,7 @@ export class NodeAttacher extends NodeLauncherBase<INodeAttachConfiguration> {
     }
 
     if (!isLoopback(run.params.address)) {
-      // todo: logger.log("Cannot attach to children of remote process")
+      logger.warn(LogTag.RuntimeTarget, 'Cannot attach to children of remote process');
       return;
     }
 
@@ -135,29 +109,5 @@ export class NodeAttacher extends NodeLauncherBase<INodeAttachConfiguration> {
       );
       return;
     }
-  }
-
-  private async gatherTelemetry(cdp: Cdp.Api) {
-    const telemetry = await cdp.Runtime.evaluate({
-      contextId: 1,
-      returnByValue: true,
-      expression: `({ processId: process.pid, nodeVersion: process.version, architecture: process.arch })`,
-    });
-
-    if (!this.program) {
-      return; // shut down
-    }
-
-    if (!telemetry) {
-      logger.error(LogTag.RuntimeTarget, 'Undefined result getting telemetry');
-      return;
-    }
-
-    if (telemetry.exceptionDetails) {
-      logger.error(LogTag.RuntimeTarget, 'Error getting telemetry', telemetry.exceptionDetails);
-      return;
-    }
-
-    this.program.gotTelemetery(telemetry.result.value);
   }
 }

--- a/src/targets/node/nodeAttacherBase.ts
+++ b/src/targets/node/nodeAttacherBase.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { AnyNodeConfiguration } from '../../configuration';
+import { NodeLauncherBase, IRunData, IProcessTelemetry } from './nodeLauncherBase';
+import { IProgram } from './program';
+import Cdp from '../../cdp/api';
+import { INodeTargetLifecycleHooks } from './nodeTarget';
+import { IDisposable } from '../../common/disposable';
+import { logger } from '../../common/logging/logger';
+import { LogTag } from '../../common/logging';
+
+/**
+ * Base class that implements common matters for attachment.
+ */
+export abstract class NodeAttacherBase<T extends AnyNodeConfiguration> extends NodeLauncherBase<T> {
+  /**
+   * Tracker for whether we're waiting to break and instrument into the main
+   * process. This is used to avoid instrumenting unecessarily into subsequent
+   * children.
+   */
+  private capturedEntryProgram?: IProgram;
+
+  /**
+   * @inheritdoc
+   */
+  protected createLifecycle(cdp: Cdp.Api, run: IRunData<T>): INodeTargetLifecycleHooks {
+    if (this.program === this.capturedEntryProgram) {
+      return {};
+    }
+
+    let toDispose: Promise<ReadonlyArray<IDisposable>> = Promise.resolve([]);
+    this.capturedEntryProgram = this.program;
+
+    return {
+      initialized: async () => {
+        toDispose = this.onFirstInitialize(cdp, run);
+        await toDispose;
+      },
+      close: async () => {
+        (await toDispose).forEach(d => d.dispose());
+      },
+    };
+  }
+
+  /**
+   * Called the first time, for each program, we get an attachment. Can
+   * return disposables to clean up when the run finishes.
+   */
+  protected async onFirstInitialize(
+    cdp: Cdp.Api,
+    run: IRunData<T>,
+  ): Promise<ReadonlyArray<IDisposable>> {
+    await this.gatherTelemetry(cdp, run);
+    return [];
+  }
+
+  /**
+   * Reads telemetry from the process.
+   */
+  protected async gatherTelemetry(
+    cdp: Cdp.Api,
+    _run: IRunData<T>,
+  ): Promise<IProcessTelemetry | void> {
+    const telemetry = await cdp.Runtime.evaluate({
+      contextId: 1,
+      returnByValue: true,
+      expression: `({ processId: process.pid, nodeVersion: process.version, architecture: process.arch })`,
+    });
+
+    if (!this.program) {
+      return; // shut down
+    }
+
+    if (!telemetry) {
+      logger.error(LogTag.RuntimeTarget, 'Undefined result getting telemetry');
+      return;
+    }
+
+    if (telemetry.exceptionDetails) {
+      logger.error(LogTag.RuntimeTarget, 'Error getting telemetry', telemetry.exceptionDetails);
+      return;
+    }
+
+    this.program.gotTelemetery(telemetry.result.value);
+    return telemetry.result.value;
+  }
+}

--- a/src/targets/node/nodeLauncherBase.ts
+++ b/src/targets/node/nodeLauncherBase.ts
@@ -66,7 +66,7 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
   /**
    * Data set while a debug session is running.
    */
-  private run?: IRunData<T>;
+  protected run?: IRunData<T>;
 
   /**
    * Attached server connections. Tracked so they can be torn down readily.
@@ -112,6 +112,8 @@ export abstract class NodeLauncherBase<T extends AnyNodeConfiguration> implement
     if (!resolved) {
       return { blockSessionTermination: false };
     }
+
+    this._stopServer(); // clear any ongoing run
 
     const { server, pipe } = await this._startServer(rawTelemetryReporter);
     const run = (this.run = {

--- a/src/targets/targets.ts
+++ b/src/targets/targets.ts
@@ -76,13 +76,18 @@ export interface IStopMetadata {
    * Any error that occurred.
    */
   error?: Error;
+
+  /**
+   * Restart parameters.
+   */
+  restart?: any;
 }
 
 export interface Launcher extends Disposable {
   launch(params: AnyLaunchConfiguration, context: ILaunchContext, rawTelemetryReporter: RawTelemetryReporterToDap): Promise<LaunchResult>;
   terminate(): Promise<void>;
   disconnect(): Promise<void>;
-  restart(rawTelemetryReporter: RawTelemetryReporterToDap): Promise<void>;
+  restart(): Promise<void>;
   onTargetListChanged: Event<void>;
   onTerminated: Event<IStopMetadata>;
   targetList(): Target[];


### PR DESCRIPTION
Just something we weren't doing. The existing adapter reads the process
ID when it attaches to a target, and so did we (for Node targets). I
shifted around some logic into a `NodeAttacherBase` so that we can
reuse that query in the extension host, and then from there we reuse
the `TerminalProgram` to track the liveness of the vscode instance
by process ID.

Things I tested that work (from a vscode 'parent' debugging a 'child'):
 - Halting debugging from inside the parent instance kills the child
 - Closing the child clears the debugging state in the parent (I think
   it's actually a minor bug in the existing debug adapters where
   this doesn't happen...)
 - Restarting works as expected

Finishes/Fixes https://github.com/microsoft/vscode-pwa/issues/58