### PR TITLE
Apply defaults to config inside adapter, without the config provider involved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1041,6 +1041,15 @@
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "dev": true
     },
+    "asn1": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
+      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": "~2.1.0"
+      }
+    },
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
@@ -1078,6 +1087,12 @@
           }
         }
       }
+    },
+    "assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assertion-error": {
       "version": "1.1.0",
@@ -1142,6 +1157,18 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
+    },
+    "aws-sign2": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
+    },
+    "aws4": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
     "azure-devops-node-api": {
@@ -1270,6 +1297,15 @@
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
       "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
       "dev": true
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "dev": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "beeper": {
       "version": "1.1.1",
@@ -1603,6 +1639,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
       "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+      "dev": true
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
       "dev": true
     },
     "chai": {
@@ -2199,6 +2241,15 @@
         "type": "^1.0.1"
       }
     },
+    "dashdash": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "date-now": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
@@ -2554,6 +2605,16 @@
       "requires": {
         "is-plain-object": "^2.0.1",
         "object.defaults": "^1.1.0"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "dev": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
       }
     },
     "ecstatic": {
@@ -3172,6 +3233,12 @@
         }
       }
     },
+    "extsprintf": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
     "fancy-log": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.3.tgz",
@@ -3458,6 +3525,23 @@
             "which": "^1.2.9"
           }
         }
+      }
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
+    },
+    "form-data": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
+      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+      "dev": true,
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12"
       }
     },
     "forwarded": {
@@ -4157,6 +4241,15 @@
       "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
       "dev": true
     },
+    "getpass": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
     "glob": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
@@ -4689,6 +4782,22 @@
         }
       }
     },
+    "har-schema": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
+    },
+    "har-validator": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
+      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.5.5",
+        "har-schema": "^2.0.0"
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -4900,6 +5009,17 @@
         "optimist": "0.6.x",
         "portfinder": "^1.0.13",
         "union": "~0.4.3"
+      }
+    },
+    "http-signature": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "https-browserify": {
@@ -5234,6 +5354,12 @@
         "has-symbols": "^1.0.0"
       }
     },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
+    },
     "is-unc-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-1.0.0.tgz",
@@ -5283,6 +5409,12 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
+      "dev": true
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
     },
     "istextorbinary": {
@@ -5339,6 +5471,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -5349,6 +5487,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
+      "dev": true
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
       "dev": true
     },
     "json-schema-traverse": {
@@ -5363,6 +5507,12 @@
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
     },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
+    },
     "json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -5370,6 +5520,18 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
+      }
+    },
+    "jsprim": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
       }
     },
     "just-debounce": {
@@ -7051,6 +7213,12 @@
         }
       }
     },
+    "oauth-sign": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+      "dev": true
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -7544,6 +7712,12 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
       "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
+    "performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
     "picomatch": {
@@ -8065,6 +8239,42 @@
           "requires": {
             "safe-buffer": "~5.1.0"
           }
+        }
+      }
+    },
+    "request": {
+      "version": "2.88.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+      "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+      "dev": true,
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+          "dev": true
         }
       }
     },
@@ -8705,6 +8915,23 @@
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
     },
+    "sshpk": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
+      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+      "dev": true,
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
+    },
     "ssri": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
@@ -9251,6 +9478,24 @@
       "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==",
       "dev": true
     },
+    "tough-cookie": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+      "dev": true,
+      "requires": {
+        "psl": "^1.1.24",
+        "punycode": "^1.4.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+          "dev": true
+        }
+      }
+    },
     "tslib": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
@@ -9296,6 +9541,21 @@
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.4.tgz",
       "integrity": "sha1-LTeFoVjBdMmhbcLARuxfxfF0IhM=",
+      "dev": true
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
     },
     "type": {
@@ -9636,6 +9896,17 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
       "dev": true
+    },
+    "verror": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "vinyl": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "npm-run-all": "^4.1.5",
     "nyc": "^14.1.1",
     "puppeteer": "^1.20.0",
+    "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
     "sinon": "^7.5.0",
     "tslint": "5.11.0",
@@ -113,6 +114,7 @@
   "enableProposedApi": true,
   "activationEvents": [
     "onDebugInitialConfigurations",
+    "onDebugResolve:node",
     "onDebugResolve:NAMESPACE(node)",
     "onDebugResolve:NAMESPACE(node-terminal)",
     "onCommand:extension.NAMESPACE(node-debug).pickNodeProcess",

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -1,23 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-import { Disposable, EventEmitter } from './common/events';
-import { DebugAdapter } from './adapter/debugAdapter';
-import { Thread } from './adapter/threads';
-import { Launcher, Target, LaunchResult } from './targets/targets';
-import * as errors from './dap/errors';
-import * as urlUtils from './common/urlUtils';
-import Dap from './dap/api';
-import DapConnection from './dap/connection';
-import { generateBreakpointIds } from './adapter/breakpoints';
-import { AnyLaunchConfiguration } from './configuration';
-import { RawTelemetryReporterToDap } from './telemetry/telemetryReporter';
-import { filterErrorsReportedToTelemetry } from './telemetry/unhandledErrorReporter';
-import { logger } from './common/logging/logger';
-import { resolveLoggerOptions, LogTag } from './common/logging';
-import { CancellationTokenSource, TaskCancelledError } from './common/cancellation';
 import { CancellationToken } from 'vscode';
 import * as nls from 'vscode-nls';
+import { generateBreakpointIds } from './adapter/breakpoints';
+import { DebugAdapter } from './adapter/debugAdapter';
+import { Thread } from './adapter/threads';
+import { CancellationTokenSource, TaskCancelledError } from './common/cancellation';
+import { Disposable, EventEmitter } from './common/events';
+import { LogTag, resolveLoggerOptions } from './common/logging';
+import { logger } from './common/logging/logger';
+import * as urlUtils from './common/urlUtils';
+import { AnyLaunchConfiguration, AnyResolvingConfiguration, applyDefaults } from './configuration';
+import Dap from './dap/api';
+import DapConnection from './dap/connection';
+import * as errors from './dap/errors';
+import { Launcher, LaunchResult, Target } from './targets/targets';
+import { RawTelemetryReporterToDap } from './telemetry/telemetryReporter';
+import { filterErrorsReportedToTelemetry } from './telemetry/unhandledErrorReporter';
 
 const localize = nls.loadMessageBundle();
 
@@ -78,8 +78,8 @@ export class Binder implements Disposable {
       dap.on('configurationDone', async () => ({}));
       dap.on('threads', async () => ({ threads: [] }));
       dap.on('loadedSources', async () => ({ sources: [] }));
-      dap.on('attach', params => this._boot(params as AnyLaunchConfiguration, dap));
-      dap.on('launch', params => this._boot(params as AnyLaunchConfiguration, dap));
+      dap.on('attach', params => this._boot(applyDefaults(params as AnyResolvingConfiguration), dap));
+      dap.on('launch', params => this._boot(applyDefaults(params as AnyResolvingConfiguration), dap));
       dap.on('terminate', async () => {
         await Promise.all([...this._launchers].map(l => l.terminate()));
         return {};

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -22,7 +22,8 @@ type OmittedKeysFromAttributes =
   | 'request'
   | 'internalConsoleOptions'
   | 'name'
-  | 'rootPath';
+  | 'rootPath'
+  | '__workspaceFolder';
 
 type ConfigurationAttributes<T> = {
   [K in keyof Omit<T, OmittedKeysFromAttributes>]: JSONSchema6 &

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -397,6 +397,7 @@ export type ResolvingExtensionHostConfiguration = ResolvingConfiguration<
 export type ResolvingNodeAttachConfiguration = ResolvingConfiguration<INodeAttachConfiguration>;
 export type ResolvingNodeLaunchConfiguration = ResolvingConfiguration<INodeLaunchConfiguration>;
 export type ResolvingTerminalConfiguration = ResolvingConfiguration<INodeTerminalConfiguration>;
+export type ResolvingNodeConfiguration = ResolvingNodeAttachConfiguration | ResolvingNodeLaunchConfiguration;
 export type ResolvingChromeConfiguration = ResolvingConfiguration<AnyChromeConfiguration>;
 export type AnyResolvingConfiguration =
   | ResolvingExtensionHostConfiguration
@@ -523,3 +524,39 @@ export const nodeAttachConfigDefaults: INodeAttachConfiguration = {
   request: 'attach',
   processId: '',
 };
+
+export function applyNodeDefaults(config: ResolvingNodeConfiguration): AnyNodeConfiguration {
+  return config.request === 'attach'
+      ? { ...nodeAttachConfigDefaults, ...config }
+      : { ...nodeLaunchConfigDefaults, ...config };
+}
+
+export function applyChromeDefaults(config: ResolvingChromeConfiguration): AnyChromeConfiguration {
+  return config.request === 'attach'
+      ? { ...chromeAttachConfigDefaults, ...config }
+      : { ...chromeLaunchConfigDefaults, ...config };
+}
+
+export function applyExtensionHostDefaults(config: ResolvingExtensionHostConfiguration): IExtensionHostConfiguration {
+    return { ...extensionHostConfigDefaults, ...config };
+}
+
+export function applyTerminalDefaults(config: ResolvingTerminalConfiguration): INodeTerminalConfiguration {
+    return { ...extensionHostConfigDefaults, ...config };
+}
+
+export function applyDefaults(config: AnyResolvingConfiguration): AnyLaunchConfiguration {
+  if (config.type === Contributions.NodeDebugType)
+    return applyNodeDefaults(config);
+
+  if (config.type === Contributions.ChromeDebugType)
+    return applyChromeDefaults(config);
+
+  if (config.type === Contributions.ExtensionHostDebugType)
+    return applyExtensionHostDefaults(config);
+
+  if (config.type === Contributions.TerminalDebugType)
+    return applyTerminalDefaults(config);
+
+  return config as AnyLaunchConfiguration;
+}

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -570,15 +570,15 @@ export function applyDefaults(config: AnyResolvingConfiguration): AnyLaunchConfi
 }
 
 function resolveWorkspaceRoot(config: AnyLaunchConfiguration): void {
-  resolveVariablesInConfig(config, 'workspaceFolder', config.__workspaceFolder);
+  resolveVariableInConfig(config, 'workspaceFolder', config.__workspaceFolder);
 }
 
-function resolveVariablesInConfig(config: any, varName: string, varValue: string): any {
+export function resolveVariableInConfig(config: any, varName: string, varValue: string): void {
   for (const key in config) {
     if (typeof config[key] === 'string') {
       config[key] = resolveVariable(config[key], varName, varValue);
-    } else {
-      resolveVariablesInConfig(config[key], varName, varValue);
+    } else if (!!config[key] && typeof config[key] === 'object') {
+      resolveVariableInConfig(config[key], varName, varValue);
     }
   }
 }

--- a/src/ui/processPicker.ts
+++ b/src/ui/processPicker.ts
@@ -4,19 +4,14 @@
 
 'use strict';
 
-import * as nls from 'vscode-nls';
-import * as vscode from 'vscode';
-import { basename } from 'path';
-import { getProcesses } from './processTree';
 import { execSync } from 'child_process';
+import { basename } from 'path';
+import * as vscode from 'vscode';
+import * as nls from 'vscode-nls';
 import { Contributions } from '../common/contributionUtils';
-import {
-  nodeAttachConfigDefaults,
-  INodeAttachConfiguration,
-  ResolvingNodeAttachConfiguration,
-} from '../configuration';
+import { INodeAttachConfiguration, nodeAttachConfigDefaults, resolveVariableInConfig, ResolvingNodeAttachConfiguration } from '../configuration';
 import { guessWorkingDirectory } from '../nodeDebugConfigurationProvider';
-import { mapValues } from '../common/objUtils';
+import { getProcesses } from './processTree';
 
 const INSPECTOR_PORT_DEFAULT = 9229;
 
@@ -42,20 +37,7 @@ export async function attachProcess() {
   }
 
   const cwd = guessWorkingDirectory();
-  const assignWorkspaceFolder = (obj: any): any =>
-    mapValues(obj, value => {
-      if (typeof value === 'string') {
-        return value.replace('${workspaceFolder}', cwd);
-      }
-
-      if (value && typeof value === 'object') {
-        return assignWorkspaceFolder(value);
-      }
-
-      return value;
-    });
-
-  config = assignWorkspaceFolder(config);
+  resolveVariableInConfig(config, 'workspaceFolder', cwd);
   return vscode.debug.startDebugging(undefined, config);
 }
 


### PR DESCRIPTION
It won't be invoked when old node-debug dispatches to pwa-node, or for the VS case
- And always activate when node-debug activates
- And add "request" back for tests