### PR TITLE
chore: add a package target to build the flatSessionLauncher for laun…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -150,14 +150,7 @@ gulp.task('compile:static', () =>
 
 gulp.task('compile', gulp.series('compile:ts', 'compile:static', 'compile:dynamic'));
 
-/** Run webpack to bundle the extension output files */
-gulp.task('package:webpack-bundle', async () => {
-  const packages = [
-    { entry: `${buildSrcDir}/extension.js`, library: true },
-    { entry: `${buildSrcDir}/${nodeTargetsDir}/bootloader.js`, library: false },
-    { entry: `${buildSrcDir}/${nodeTargetsDir}/watchdog.js`, library: false },
-  ];
-
+async function runWebpack(packages) {
   for (const { entry, library } of packages) {
     const config = {
       mode: 'production',
@@ -193,6 +186,28 @@ gulp.task('package:webpack-bundle', async () => {
       }),
     );
   }
+}
+
+/** Run webpack to bundle the extension output files */
+gulp.task('package:webpack-bundle', async () => {
+  const packages = [
+    { entry: `${buildSrcDir}/extension.js`, library: true },
+    { entry: `${buildSrcDir}/${nodeTargetsDir}/bootloader.js`, library: false },
+    { entry: `${buildSrcDir}/${nodeTargetsDir}/watchdog.js`, library: false },
+  ];
+
+  return runWebpack(packages);
+});
+
+/** Run webpack to bundle into the flat session launcher (for VS or standalone debug server)  */
+gulp.task('flatSessionBundle:webpack-bundle', async () => {
+  const packages = [
+    { entry: `${buildSrcDir}/flatSessionLauncher.js`, library: true },
+    { entry: `${buildSrcDir}/${nodeTargetsDir}/bootloader.js`, library: false },
+    { entry: `${buildSrcDir}/${nodeTargetsDir}/watchdog.js`, library: false },
+  ];
+
+  return runWebpack(packages);
 });
 
 /** Copy the extension static files */
@@ -233,6 +248,16 @@ gulp.task(
     'package:webpack-bundle',
     'package:copy-extension-files',
     'package:createVSIX',
+  ),
+);
+
+gulp.task(
+  'flatSessionBundle',
+  gulp.series(
+    'clean',
+    'compile',
+    'flatSessionBundle:webpack-bundle',
+    'package:copy-extension-files',
   ),
 );
 

--- a/src/flatSessionLauncher.ts
+++ b/src/flatSessionLauncher.ts
@@ -109,7 +109,7 @@ function main(inputStream: NodeJS.ReadableStream, outputStream: NodeJS.WritableS
   connection.init(inputStream, outputStream);
 }
 
-const debugServerPort = process.argv.length >= 3 ? +process.argv[2] : 0;
+const debugServerPort = process.argv.length >= 3 ? +process.argv[2] : undefined;
 if(debugServerPort !== undefined) {
   const server = net.createServer(async socket => {
     main(socket, socket);


### PR DESCRIPTION
…ching independently of vscode

Also a small fix in the flatSessionLauncher to allow launching using stdin/out (defaulted to using port 0 with sockets if user didn't pass a port param)