### PR TITLE
feat: support webpack namespaces in source map overrides

### DIFF
--- a/demos/webpack/.vscode/launch.json
+++ b/demos/webpack/.vscode/launch.json
@@ -12,6 +12,14 @@
       "preLaunchTask": "npm: compile-node"
     },
     {
+      "type": "pwa-node",
+      "request": "launch",
+      "smartStep": false,
+      "trace": true,
+      "name": "[Webpack]: Consume Lib In Node",
+      "program": "${workspaceFolder}/src/consume-lib.js",
+    },
+    {
       "type": "pwa-chrome",
       "request": "launch",
       "name": "[Webpack]: In Browser",

--- a/demos/webpack/package-lock.json
+++ b/demos/webpack/package-lock.json
@@ -1868,12 +1868,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -1892,6 +1894,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2071,7 +2074,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2177,7 +2181,8 @@
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/demos/webpack/src/consume-lib.js
+++ b/demos/webpack/src/consume-lib.js
@@ -1,0 +1,2 @@
+const lib = require('../out/lib');
+console.log(lib.double(21));

--- a/demos/webpack/src/lib.ts
+++ b/demos/webpack/src/lib.ts
@@ -1,0 +1,3 @@
+export function double(x: number) {
+  return x * 2;
+}

--- a/demos/webpack/webpack.lib.js
+++ b/demos/webpack/webpack.lib.js
@@ -1,0 +1,28 @@
+const path = require('path');
+
+module.exports = {
+  target: 'node',
+  mode: 'development',
+  devtool: 'source-map',
+  entry: './src/lib.ts',
+  module: {
+    rules: [
+      {
+        loader: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  node: {
+    __dirname: false,
+  },
+  resolve: {
+    extensions: ['.ts', '.js'],
+  },
+  output: {
+    filename: 'lib.js',
+    path: path.resolve(__dirname, 'out'),
+    library: 'lib',
+    libraryTarget: 'umd',
+  },
+};

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -12,6 +12,7 @@ import {
   IChromeLaunchConfiguration,
   IChromeAttachConfiguration,
   INodeTerminalConfiguration,
+  baseDefaults,
 } from '../configuration';
 import { JSONSchema6 } from 'json-schema';
 import strings from './strings';
@@ -104,13 +105,7 @@ const baseConfigurationAttributes: ConfigurationAttributes<IBaseConfiguration> =
   sourceMapPathOverrides: {
     type: 'object',
     description: refString('node.sourceMapPathOverrides.description'),
-    default: {
-      'webpack:///./*': '${webRoot}/*',
-      'webpack:///src/*': '${webRoot}/*',
-      'webpack:///*': '*',
-      'webpack:///./~/*': '${webRoot}/node_modules/*',
-      'meteor://💻app/*': '${webRoot}/*',
-    },
+    default: baseDefaults.sourceMapPathOverrides,
   },
   timeout: {
     type: 'number',

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -436,7 +436,7 @@ export const baseDefaults: IBaseConfiguration = {
   rootPath: '${workspaceFolder}',
   // keep in sync with sourceMapPathOverrides in package.json
   sourceMapPathOverrides: {
-    'webpack:///*': '*',
+    'webpack://?:*/*': '*',
     'webpack:///./~/*': '${workspaceFolder}/node_modules/*',
     'meteor://💻app/*': '${workspaceFolder}/*',
   },

--- a/src/targets/browser/browserPathResolver.ts
+++ b/src/targets/browser/browserPathResolver.ts
@@ -46,7 +46,7 @@ export class BrowserSourcePathResolver extends SourcePathResolverBase<IOptions> 
       return '';
     }
 
-    const unmappedPath = this.applyPathOverrides(url);
+    const unmappedPath = this.sourceMapOverrides.apply(url);
     if (unmappedPath !== url) {
       return path.resolve(webRoot, unmappedPath);
     }

--- a/src/targets/node/nodeSourcePathResolver.ts
+++ b/src/targets/node/nodeSourcePathResolver.ts
@@ -25,7 +25,7 @@ export class NodeSourcePathResolver extends SourcePathResolverBase<IOptions> {
       return '';
     }
 
-    const withBase = path.resolve(this.options.basePath, this.applyPathOverrides(url));
+    const withBase = path.resolve(this.options.basePath, this.sourceMapOverrides.apply(url));
     return this.rebaseRemoteToLocal(withBase);
   }
 

--- a/src/targets/sourceMapOverrides.ts
+++ b/src/targets/sourceMapOverrides.ts
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { forceForwardSlashes, properJoin } from '../common/pathUtils';
+import { logger } from '../common/logging/logger';
+import { LogTag } from '../common/logging';
+import { escapeRegexSpecialChars } from '../common/stringUtils';
+
+// Patterns to match against various patterns:
+const capturingGroup = '*';
+const capturingGroupRe = new RegExp(escapeRegexSpecialChars(capturingGroup), 'g');
+const nonCapturingGroup = '?:' + capturingGroup;
+const nonCapturingGroupRe = new RegExp(escapeRegexSpecialChars(nonCapturingGroup), 'g');
+
+const occurencesInString = (re: RegExp, str: string) => {
+  const matches = str.match(re);
+  re.lastIndex = 0;
+  return matches ? matches.length : 0;
+};
+
+const anyGroupRe = new RegExp(
+  `${escapeRegexSpecialChars(nonCapturingGroup)}|${escapeRegexSpecialChars(capturingGroup)}`,
+  'g',
+);
+
+/**
+ * Contains a collection of source map overrides, and can apply those to strings.
+ */
+export class SourceMapOverrides {
+  /**
+   * Mapping of regexes to replacement patterns. The regexes should return
+   * the value to replace in their first matching group, and the patterns
+   * will have their asterisk '*', if any, replaced.
+   */
+  private readonly replacers: [RegExp, string][] = [];
+
+  constructor(sourceMapOverrides: { [from: string]: string }) {
+    // Sort the overrides by length, large to small
+    const sortedOverrideKeys = Object.keys(sourceMapOverrides).sort((a, b) => b.length - a.length);
+
+    // Iterate the key/vals, only apply the first one that matches.
+    for (let leftPattern of sortedOverrideKeys) {
+      const rightPattern = sourceMapOverrides[leftPattern];
+      const entryStr = `"${leftPattern}": "${rightPattern}"`;
+
+      const capturedGroups =
+        occurencesInString(capturingGroupRe, leftPattern) -
+        occurencesInString(nonCapturingGroupRe, leftPattern);
+
+      if (capturedGroups > 1) {
+        logger.warn(
+          LogTag.RuntimeSourceMap,
+          `Warning: only one asterisk allowed in a sourceMapPathOverrides entry - ${entryStr}`,
+        );
+        continue;
+      }
+
+      if (occurencesInString(capturingGroupRe, rightPattern) > capturedGroups) {
+        logger.warn(
+          LogTag.RuntimeSourceMap,
+          `The right side of a sourceMapPathOverrides entry must have 0 or 1 asterisks - ${entryStr}}`,
+        );
+        continue;
+      }
+
+      let reSource = '^';
+      let leftIndex = 0;
+      while (true) {
+        const next = anyGroupRe.exec(leftPattern);
+        reSource += escapeRegexSpecialChars(leftPattern.slice(leftIndex, next?.index), '/');
+
+        if (!next) {
+          this.replacers.push([new RegExp(reSource + '$', 'i'), rightPattern]);
+          break;
+        }
+
+        if (next[0] === capturingGroup) {
+          reSource += '(.*?)';
+        } else {
+          reSource += '.*?';
+        }
+
+        leftIndex = next.index + next[0].length;
+      }
+
+      anyGroupRe.lastIndex = 0;
+    }
+  }
+
+  /**
+   * Applies soruce map overrides to the path. The path should should given
+   * as a filesystem path, not a URI.
+   */
+  public apply(sourcePath: string): string {
+    const sourcePathWithForwardSlashes = forceForwardSlashes(sourcePath);
+    for (const [re, replacement] of this.replacers) {
+      const parts = re.exec(sourcePathWithForwardSlashes);
+      if (!parts) {
+        continue;
+      }
+
+      // Grab the value of the wildcard from the match, replace the wildcard in the
+      // replacement pattern, and return the result.
+      const mappedPath = replacement.replace('*', parts[1]);
+
+      logger.verbose(
+        LogTag.RuntimeSourceMap,
+        `SourceMap: mapping ${sourcePath} => ${mappedPath}, via sourceMapPathOverrides entry - ${re.toString()}`,
+      );
+
+      return properJoin(mappedPath);
+    }
+
+    return sourcePath;
+  }
+}

--- a/src/targets/sourcePathResolver.ts
+++ b/src/targets/sourcePathResolver.ts
@@ -2,9 +2,7 @@
 // Licensed under the MIT license.
 
 import { ISourcePathResolver, IUrlResolution } from '../common/sourcePathResolver';
-import { escapeRegexSpecialChars } from '../common/stringUtils';
 import {
-  properJoin,
   fixDriveLetter,
   fixDriveLetterAndSlashes,
   forceForwardSlashes,
@@ -12,11 +10,11 @@ import {
 } from '../common/pathUtils';
 import * as path from 'path';
 import { isFileUrl, fileUrlToAbsolutePath, getCaseSensitivePaths } from '../common/urlUtils';
-import { baseDefaults } from '../configuration';
 import { logger } from '../common/logging/logger';
 import { LogTag } from '../common/logging';
 import { SourceMap } from '../common/sourceMaps/sourceMap';
 import match from 'micromatch';
+import { SourceMapOverrides } from './sourceMapOverrides';
 
 export interface ISourcePathResolverOptions {
   resolveSourceMapLocations: ReadonlyArray<string> | null;
@@ -27,6 +25,7 @@ export interface ISourcePathResolverOptions {
 
 export abstract class SourcePathResolverBase<T extends ISourcePathResolverOptions>
   implements ISourcePathResolver {
+    protected readonly sourceMapOverrides = new SourceMapOverrides(this.options.sourceMapOverrides);
   constructor(protected readonly options: T) {}
 
   public abstract urlToAbsolutePath(request: IUrlResolution): string | undefined;
@@ -107,68 +106,13 @@ export abstract class SourcePathResolverBase<T extends ISourcePathResolverOption
     return remotePath;
   }
 
-  /**
-   * Applies soruce map overrides to the path. The path should should given
-   * as a filesystem path, not a URI.
-   */
-  protected applyPathOverrides(sourcePath: string) {
-    const { sourceMapOverrides = baseDefaults.sourceMapPathOverrides } = this.options;
-    const forwardSlashSourcePath = sourcePath.replace(/\\/g, '/');
-
-    // Sort the overrides by length, large to small
-    const sortedOverrideKeys = Object.keys(sourceMapOverrides).sort((a, b) => b.length - a.length);
-
-    // Iterate the key/vals, only apply the first one that matches.
-    for (let leftPattern of sortedOverrideKeys) {
-      const rightPattern = sourceMapOverrides[leftPattern];
-      const entryStr = `"${leftPattern}": "${rightPattern}"`;
-
-      const asterisks = leftPattern.match(/\*/g) || [];
-      if (asterisks.length > 1) {
-        logger.warn(
-          LogTag.RuntimeSourceMap,
-          `Warning: only one asterisk allowed in a sourceMapPathOverrides entry - ${entryStr}`,
-        );
-        continue;
-      }
-
-      const replacePatternAsterisks = rightPattern.match(/\*/g) || [];
-      if (replacePatternAsterisks.length > asterisks.length) {
-        logger.warn(
-          LogTag.RuntimeSourceMap,
-          `The right side of a sourceMapPathOverrides entry must have 0 or 1 asterisks - ${entryStr}}`,
-        );
-        continue;
-      }
-
-      // Does it match?
-      const escapedLeftPattern = escapeRegexSpecialChars(leftPattern, '/*');
-      const leftRegexSegment = escapedLeftPattern.replace(/\*/g, '(.*)').replace(/\\\\/g, '/');
-      const leftRegex = new RegExp(`^${leftRegexSegment}$`, 'i');
-      const overridePatternMatches = forwardSlashSourcePath.match(leftRegex);
-      if (!overridePatternMatches) continue;
-
-      // Grab the value of the wildcard from the match above, replace the wildcard in the
-      // replacement pattern, and return the result.
-      const wildcardValue = overridePatternMatches[1];
-      let mappedPath = rightPattern.replace(/\*/g, wildcardValue);
-
-      logger.verbose(
-        LogTag.RuntimeSourceMap,
-        `SourceMap: mapping ${sourcePath} => ${mappedPath}, via sourceMapPathOverrides entry - ${entryStr}`,
-      );
-      return properJoin(mappedPath);
-    }
-
-    return sourcePath;
-  }
-
   private canMapPath(candidate: string) {
     return (
       path.posix.isAbsolute(candidate) || path.win32.isAbsolute(candidate) || isFileUrl(candidate)
     );
   }
 }
+
 
 /**
  * Cross-platform path.resolve

--- a/src/test/common/sourceMapOverrides.test.ts
+++ b/src/test/common/sourceMapOverrides.test.ts
@@ -1,0 +1,55 @@
+/*---------------------------------------------------------
+ * Copyright (C) Microsoft Corporation. All rights reserved.
+ *--------------------------------------------------------*/
+
+import { expect } from 'chai';
+import { SourceMapOverrides } from '../../targets/sourceMapOverrides';
+import { baseDefaults } from '../../configuration';
+
+describe('SourceMapOverrides', () => {
+  describe('functionality', () => {
+    it('replaces simple paths', () => {
+      const r = new SourceMapOverrides({ '/a/*': '/b/*' });
+      expect(r.apply('/a/foo/bar')).to.equal('/b/foo/bar');
+      expect(r.apply('/q/foo/bar')).to.equal('/q/foo/bar');
+    });
+
+    it('replaces paths without groups on the right', () => {
+      const r = new SourceMapOverrides({ '/a/*': '/b' });
+      expect(r.apply('/a/foo/bar')).to.equal('/b');
+    });
+
+    it('replaces paths without groups on the left or right', () => {
+      const r = new SourceMapOverrides({ '/a': '/b' });
+      expect(r.apply('/a/foo/bar')).to.equal('/a/foo/bar');
+      expect(r.apply('/a')).to.equal('/b');
+    });
+
+    it('handles non-capturing groups', () => {
+      const r = new SourceMapOverrides({ '/a/?:*/*': '/b/*' });
+      expect(r.apply('/a/foo/bar')).to.equal('/b/bar');
+    });
+
+    it('applies longer replacements first', () => {
+      const r = new SourceMapOverrides({ '/a/*': '/c', '/a/foo': '/b' });
+      expect(r.apply('/a/foo')).to.equal('/b');
+    });
+  });
+
+  describe('defaults', () => {
+    const r = new SourceMapOverrides(baseDefaults.sourceMapPathOverrides);
+
+    it('does not touch already valid paths', () => {
+      expect(r.apply('https://contoso.com/foo.ts')).to.equal('https://contoso.com/foo.ts');
+      expect(r.apply('file:///dev/foo.ts')).to.equal('file:///dev/foo.ts');
+    });
+
+    it('resolves webpack paths', () => {
+      expect(r.apply('webpack:///src/index.ts')).to.equal('src/index.ts');
+    });
+
+    it('replaces webpack namespaces', () => {
+      expect(r.apply('webpack://lib/src/index.ts')).to.equal('src/index.ts');
+    });
+  });
+});


### PR DESCRIPTION
This involved adding a 'non-capturing group' syntax for the host map
overrides section. I used the RegEx-style `?:*` sequence, which is not
that pretty, I'm open to ideas. Anyway, this works. The default
source map URIs in webpack are actually formed[1] like:

```
webpack://[namespace]/[resourcePath]
```

It just happens the namespace is usually empty for main targets, but
this is configurable is defaults to `lib` for library targets,
hence #60. This PR adds a non-capturing group for the namespace.

Also makes source map overrides its own class, which saves processing
time (we can pre-parse and generate the regexes) and makes it more
readily testable.

 1. https://github.com/webpack/webpack/blob/91a9f97657b34375cd99e8ba8ef13dd795f1e7c3/lib/SourceMapDevToolPlugin.js#L115