### PR TITLE
feat: chrome behavior parity, allow debugging vscode

### DIFF
--- a/src/cdp/transport.ts
+++ b/src/cdp/transport.ts
@@ -6,7 +6,7 @@ import WebSocket from 'ws';
 import * as events from 'events';
 import { HighResolutionTime } from '../utils/performance';
 import { CancellationToken } from 'vscode';
-import { cancellableRace } from '../common/cancellation';
+import { timeoutPromise } from '../common/cancellation';
 
 export interface Transport {
   send(message: string): void;
@@ -92,7 +92,7 @@ export class WebSocketTransport implements Transport {
       maxPayload: 256 * 1024 * 1024, // 256Mb
     });
 
-    return cancellableRace(
+    return timeoutPromise(
       new Promise<WebSocketTransport>((resolve, reject) => {
         ws.addEventListener('open', () => resolve(new WebSocketTransport(ws, url)));
         ws.addEventListener('error', reject);

--- a/src/common/findOpenPort.ts
+++ b/src/common/findOpenPort.ts
@@ -3,25 +3,44 @@
  *--------------------------------------------------------*/
 
 import { createServer, AddressInfo } from 'net';
+import { CancellationToken } from 'vscode';
+import { NeverCancelled, TaskCancelledError } from './cancellation';
+import { IDisposable } from './disposable';
 
 /**
  * Finds an open TCP port that can be listened on.
  */
-export async function findOpenPort(maxAttempts = 1000) {
+export async function findOpenPort(maxAttempts = 1000, ct?: CancellationToken) {
   for (let i = 0; ; i++) {
     const port = 3000 + Math.floor(Math.random() * 50000);
     try {
       await assertPortOpen(port);
       return port;
     } catch (e) {
-      if (i >= maxAttempts) {
+      if (i >= maxAttempts || e instanceof TaskCancelledError) {
         throw e;
       }
     }
   }
 }
 
-export function assertPortOpen(port: number) {
+/**
+ * Checks whether the port is open.
+ */
+export async function isPortOpen(port: number, ct?: CancellationToken) {
+  try {
+    await assertPortOpen(port, ct);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Checks that the port is open, throwing an error if not.
+ */
+export function assertPortOpen(port: number, ct: CancellationToken = NeverCancelled) {
+  let disposable: IDisposable | undefined;
   return new Promise((resolve, reject) => {
     const server = createServer();
     server.listen(port, () => {
@@ -29,5 +48,10 @@ export function assertPortOpen(port: number) {
       server.on('error', reject);
       server.close(() => resolve(address.port));
     });
-  });
+
+    disposable = ct.onCancellationRequested(() => {
+      server.close();
+      reject(new TaskCancelledError('Port open lookup cancelled'));
+    });
+  }).finally(() => disposable?.dispose());
 }

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -279,9 +279,10 @@ export interface IChromeBaseConfiguration extends IBaseConfiguration {
   webRoot: string;
 
   /**
-   * Will search for a tab with this exact url and attach to it, if found.
+   * Will navigate to this URL and attach to it. This can be omitted to
+   * avoid navigation.
    */
-  url: string;
+  url: string | null;
 
   /**
    * Will search for a page with this url and attach to it, if found.
@@ -496,7 +497,7 @@ export const chromeAttachConfigDefaults: IChromeAttachConfiguration = {
   port: 0,
   disableNetworkCache: true,
   pathMapping: {},
-  url: 'http://localhost:8080',
+  url: null,
   urlFilter: '',
   webRoot: '${workspaceFolder}',
 };
@@ -510,7 +511,7 @@ export const chromeLaunchConfigDefaults: IChromeLaunchConfiguration = {
   env: {},
   runtimeArgs: null,
   runtimeExecutable: 'stable',
-  userDataDir: true,
+  userDataDir: false,
   server: null,
 };
 

--- a/src/test/common/cancellation.test.ts
+++ b/src/test/common/cancellation.test.ts
@@ -7,7 +7,7 @@ import { expect } from 'chai';
 import {
   CancellationTokenSource,
   NeverCancelled,
-  cancellableRace,
+  timeoutPromise,
   Cancelled,
   TaskCancelledError,
 } from '../../common/cancellation';
@@ -126,13 +126,13 @@ describe('CancellationToken', () => {
 
   describe('cancellableRace', () => {
     it('returns the value when no cancellation is requested', async () => {
-      const v = await cancellableRace(Promise.resolve(42), NeverCancelled);
+      const v = await timeoutPromise(Promise.resolve(42), NeverCancelled);
       expect(v).to.equal(42);
     });
 
     it('throws if cancellation is requested', async () => {
       try {
-        await cancellableRace(Promise.resolve(42), Cancelled);
+        await timeoutPromise(Promise.resolve(42), Cancelled);
         throw new Error('expected to throw');
       } catch (e) {
         if (e instanceof TaskCancelledError) {
@@ -145,7 +145,7 @@ describe('CancellationToken', () => {
 
     it('throws if lazy cancellation is requested', async () => {
       try {
-        await cancellableRace(
+        await timeoutPromise(
           delay(1000),
           CancellationTokenSource.withTimeout(3).token,
           'Could not do the thing',


### PR DESCRIPTION
We use the Chrome debugger to debug VS Code itself. Launching this
depended on some specific behaviors  we didn't have before:

 - the URL is optional by default, only navigate
   the page if a URL is provided
 - don't set the user data dir unless explicitly requested when a
   custom runtime executable is provided
 - when a port is provided, skip scanning the browser stdout and instead
   just poll for the debugger on that port (vscode's launch script
   didn't display the magic string the launcher was after)
 - some cleanup as I was debugging in the chrome launcher; allow
   providing the `--remote-debugging-port` to be equivalent to an
   explicit `port` option.