### PR TITLE
Ignore telemetry events in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "watch": "gulp watch",
     "package": "gulp package",
     "publish": "gulp publish",
-    "test": "gulp --drop-in && node ./out/src/test/runTest.js",
+    "test": "gulp && node ./out/src/test/runTest.js",
     "intTest": "mocha --exit --timeout 20000 -s 3500 -u tdd --colors --reporter out/src/int-chrome/testSupport/loggingReporter.js \"./out/src/int-chrome/**/*.test.js\""
   },
   "dependencies": {

--- a/src/test/logger.ts
+++ b/src/test/logger.ts
@@ -86,7 +86,7 @@ export class Logger {
 
   async logOutput(params: Dap.OutputEventParams, options?: LogOptions) {
     const prefix = `${params.category}> `;
-    if (params.output)
+    if (params.output && params.category !== 'telemetry') // We don't test telemetry events at the moment
       this.logAsConsole(`${prefix}${params.output}`);
     if (params.variablesReference) {
       const result = await this._dap.variables({ variablesReference: params.variablesReference });

--- a/src/test/testIntegrationUtils.ts
+++ b/src/test/testIntegrationUtils.ts
@@ -6,6 +6,7 @@ import { testWorkspace, testFixturesDir, TestRoot } from './test';
 import { GoldenText } from './goldenText';
 import * as child_process from 'child_process';
 import * as path from 'path';
+import { TestFunction, ExclusiveTestFunction } from 'mocha';
 
 let servers: child_process.ChildProcess[];
 
@@ -32,8 +33,8 @@ interface IIntegrationState {
   r: TestRoot;
 }
 
-export const itIntegrates = (test: string, fn: (s: IIntegrationState) => Promise<void> | void) =>
-  it(test, async function() {
+const itIntegratesBasic = (test: string, fn: (s: IIntegrationState) => Promise<void> | void, testFunction: TestFunction | ExclusiveTestFunction = it) =>
+testFunction(test, async function() {
     const golden = new GoldenText(this.test!.titlePath().join(' '), testWorkspace);
     const root = new TestRoot(golden);
     await root.initialize;
@@ -52,6 +53,9 @@ export const itIntegrates = (test: string, fn: (s: IIntegrationState) => Promise
       throw new Error(`Whoa, test "${test}" has some logs that it did not assert!`);
     }
   });
+
+itIntegratesBasic.only = (test: string, fn: (s: IIntegrationState) => Promise<void> | void) => itIntegratesBasic(test, fn, it.only);
+export const itIntegrates = itIntegratesBasic;
 
 afterEach(async () => {
   await del([`${testFixturesDir}/**`], { force: true /* delete outside cwd */ });


### PR DESCRIPTION
This solves part of the telemetry events not being matched in the expected text for some tests.

I have a lot of unit test failures when I run the tests, so it's difficult to see whether this addresses all the telemetry issues in the tests or not.

I added a .only option to itIntegrates