### PR TITLE
Fix/vscode slowness

### DIFF
--- a/src/adapter/breakpointPredictor.ts
+++ b/src/adapter/breakpointPredictor.ts
@@ -46,6 +46,17 @@ export class BreakpointsPredictor {
       .then(exists => (exists ? nodeModules : undefined));
   }
 
+  /**
+   * Returns a promise that resolves once maps in the root are predicted.
+   */
+  public async prepareToPredict(): Promise<void> {
+    await this._directoryScanner(this._rootPath).waitForLoad();
+  }
+
+  /**
+   * Returns a promise that resolves when breakpoints for the given location
+   * are predicted.
+   */
   public async predictBreakpoints(params: Dap.SetBreakpointsParams): Promise<void> {
     if (!params.source.path) return;
     const nodeModules = await this._nodeModules;
@@ -59,6 +70,9 @@ export class BreakpointsPredictor {
     await this._directoryScanner(root).predictResolvedLocations(params);
   }
 
+  /**
+   * Returns predicted breakpoint locations for the provided source.
+   */
   public predictedResolvedLocations(location: WorkspaceLocation): WorkspaceLocation[] {
     const result: WorkspaceLocation[] = [];
     for (const p of this._predictedLocations) {
@@ -130,6 +144,14 @@ class DirectoryScanner {
     }
 
     return sourcePathToCompiled;
+  }
+
+  /**
+   * Returns a promise that resolves when the sourcemaps predictions are
+   * successfully prepared.
+   */
+  public async waitForLoad() {
+    await this._sourcePathToCompiled;
   }
 
   public async predictResolvedLocations(params: Dap.SetBreakpointsParams) {

--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -466,7 +466,6 @@ export class BreakpointManager {
     this._totalBreakpointsCount += breakpoints.length;
     if (this._thread) {
       breakpoints.forEach(b => b.set(this._thread!));
-      this._updateSourceMapHandler(this._thread);
     }
     const dapBreakpoints = breakpoints.map(b => b.toProvisionalDap());
     this._breakpointsStatisticsCalculator.registerBreakpoints(dapBreakpoints);

--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -249,7 +249,11 @@ export class BreakpointManager {
   private _predictorDisabledForTest = false;
   private _breakpointsStatisticsCalculator = new BreakpointsStatisticsCalculator();
 
-  constructor(dap: Dap.Api, sourceContainer: SourceContainer) {
+  constructor(
+    dap: Dap.Api,
+    sourceContainer: SourceContainer,
+    private readonly pauseForSourceMaps: boolean,
+  ) {
     this._dap = dap;
     this._sourceContainer = sourceContainer;
 
@@ -275,6 +279,7 @@ export class BreakpointManager {
         remainPaused: result.some(r => r.some(l => l.columnNumber <= 1 && l.lineNumber <= 1)),
       };
     };
+
     if (sourceContainer.rootPath)
       this._breakpointsPredictor = new BreakpointsPredictor(
         sourceContainer.rootPath,
@@ -357,11 +362,14 @@ export class BreakpointManager {
             // inlined amongst the range we request).
             const result: Dap.BreakpointLocation[] = [];
             for (const location of r.locations) {
-              const sourceLocations = this._sourceContainer.currentSiblingUiLocations({
-                source: start.source,
-                lineNumber: location.lineNumber + 1,
-                columnNumber: (location.columnNumber || 0) + 1,
-              }, source);
+              const sourceLocations = this._sourceContainer.currentSiblingUiLocations(
+                {
+                  source: start.source,
+                  lineNumber: location.lineNumber + 1,
+                  columnNumber: (location.columnNumber || 0) + 1,
+                },
+                source,
+              );
 
               for (const srcLocation of sourceLocations) {
                 result.push({ line: srcLocation.lineNumber, column: srcLocation.columnNumber });
@@ -399,7 +407,7 @@ export class BreakpointManager {
     });
     for (const breakpoints of this._byPath.values()) breakpoints.forEach(b => b.set(thread));
     for (const breakpoints of this._byRef.values()) breakpoints.forEach(b => b.set(thread));
-    this._updateSourceMapHandler();
+    this._updateSourceMapHandler(this._thread);
   }
 
   launchBlocker(): Promise<void> {
@@ -414,11 +422,28 @@ export class BreakpointManager {
     this._predictorDisabledForTest = disabled;
   }
 
-  async _updateSourceMapHandler() {
-    if (!this._thread) return;
-    // TODO: disable pausing before source map with a setting or unconditionally.
-    // const enableSourceMapHandler = this._totalBreakpointsCount && !this._sourceMapPauseDisabledForTest;
-    await this._thread.setScriptSourceMapHandler(this._scriptSourceMapHandler);
+  async _updateSourceMapHandler(thread: Thread) {
+    if (this.pauseForSourceMaps) {
+      await thread.setScriptSourceMapHandler(this._scriptSourceMapHandler);
+    }
+
+    if (!this._breakpointsPredictor) {
+      return;
+    }
+
+    // If we set a predictor and don't want to pause, we still wait to wait
+    // for the predictor to finish running. Uninstall the sourcemap handler
+    // once we see the predictor is ready to roll, and if we get a sourcemap
+    // in the meantime wait for the predictor to finish before allowing
+    // the attached client to continue.
+    const prepared = this._breakpointsPredictor.prepareToPredict();
+    await thread.setScriptSourceMapHandler(async (script, sources) => {
+      await prepared;
+      return this._scriptSourceMapHandler(script, sources);
+    });
+
+    await prepared;
+    thread.setScriptSourceMapHandler(undefined);
   }
 
   async setBreakpoints(
@@ -449,8 +474,10 @@ export class BreakpointManager {
       await Promise.all(previous.map(b => b.remove()));
     }
     this._totalBreakpointsCount += breakpoints.length;
-    if (this._thread) breakpoints.forEach(b => b.set(this._thread!));
-    this._updateSourceMapHandler();
+    if (this._thread) {
+      breakpoints.forEach(b => b.set(this._thread!));
+      this._updateSourceMapHandler(this._thread);
+    }
     const dapBreakpoints = breakpoints.map(b => b.toProvisionalDap());
     this._breakpointsStatisticsCalculator.registerBreakpoints(dapBreakpoints);
     return { breakpoints: dapBreakpoints };

--- a/src/adapter/debugAdapter.ts
+++ b/src/adapter/debugAdapter.ts
@@ -58,7 +58,7 @@ export class DebugAdapter {
     this.dap.on('prettyPrintSource', params => this._prettyPrintSource(params));
     this.dap.on('breakpointLocations', params => this._withThread(async thread => ({ breakpoints: await this.breakpointManager.getBreakpointLocations(thread, params) })));
     this.sourceContainer = new SourceContainer(this.dap, rootPath, sourcePathResolver);
-    this.breakpointManager = new BreakpointManager(this.dap, this.sourceContainer);
+    this.breakpointManager = new BreakpointManager(this.dap, this.sourceContainer, launchConfig.pauseForSourceMap);
     this._rawTelemetryReporter.flush.event(() => {
       this._rawTelemetryReporter.report('breakpointsStatistics', this.breakpointManager.statisticsForTelemetry());
     });

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -1002,7 +1002,7 @@ export class Thread implements VariableStoreDelegate {
     if (this._scriptWithSourceMapHandler === handler)
       return;
     this._scriptWithSourceMapHandler = handler;
-    const needsPause = this._sourceContainer.sourceMapTimeouts().scriptPaused && this._scriptWithSourceMapHandler;
+    const needsPause = this._sourceContainer.sourceMapTimeouts().scriptPaused && handler;
     if (needsPause && !this._pauseOnSourceMapBreakpointId) {
       const result = await this._cdp.Debugger.setInstrumentationBreakpoint({ instrumentation: 'beforeScriptWithSourceMapExecution' });
       this._pauseOnSourceMapBreakpointId = result ? result.breakpointId : undefined;

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -96,6 +96,7 @@ export class Thread implements VariableStoreDelegate {
   private _sourceMapDisabler?: SourceMapDisabler;
   // url => (hash => Source)
   private _scriptSources = new Map<string, Map<string, Source>>();
+  private _sourceMapLoads = new Map<string, Promise<{ remainPaused: boolean }>>();
   private _smartStepper: SmartStepper;
 
   constructor(
@@ -868,37 +869,52 @@ export class Thread implements VariableStoreDelegate {
       (source as any)[kScriptsSymbol] = new Set();
     (source as any)[kScriptsSymbol].add(script);
 
-    if (!this._pauseOnSourceMapBreakpointId && event.sourceMapURL) {
-      // If we won't pause before executing this script, try to load source map
-      // and set breakpoints as soon as possible. This is still racy against the script execution,
-      // but better than nothing.
-      this._sourceContainer.waitForSourceMapSources(source).then(sources => {
-        if (sources.length && this._scriptWithSourceMapHandler)
-          this._scriptWithSourceMapHandler(script, sources);
-      });
+    if (event.sourceMapURL) {
+      // If we won't pause before executing this script, still try to load source
+      // map and set breakpoints as soon as possible. This is racy against the
+      // script execution, but better than nothing.
+      this._getOrStartLoadingSourceMaps(script);
     }
   }
 
   // Wait for source map to load and set all breakpoints in this particular script.
   async _handleSourceMapPause(scriptId: string): Promise<boolean> {
     this._pausedForSourceMapScriptId = scriptId;
+    const timeout = this._sourceContainer.sourceMapTimeouts().scriptPaused;
     const script = this._scripts.get(scriptId);
-
-    let remainPaused = false;
-    if (script) {
-      const timeout = this._sourceContainer.sourceMapTimeouts().scriptPaused;
-      const sources = await Promise.race([
-        this._sourceContainer.waitForSourceMapSources(script.source),
-        delay(timeout),
-      ]);
-      if (sources && this._scriptWithSourceMapHandler) {
-        remainPaused = (await this._scriptWithSourceMapHandler(script, sources)).remainPaused;
-      }
+    if (!script) {
+      return false;
     }
+
+    const result = await Promise.race([
+      this._getOrStartLoadingSourceMaps(script),
+      delay(timeout),
+    ]);
     console.assert(this._pausedForSourceMapScriptId === scriptId);
     this._pausedForSourceMapScriptId = undefined;
 
-    return remainPaused;
+    return result ? result.remainPaused : false;
+  }
+
+  /**
+   * Loads sourcemaps for the given script and invokes the handler, if we
+   * haven't already done so. Returns a promise that resolves with the
+   * handler's results.
+   */
+  private _getOrStartLoadingSourceMaps(script: Script) {
+    const existing = this._sourceMapLoads.get(script.scriptId);
+    if (existing) {
+      return existing;
+    }
+
+    const result = this._sourceContainer.waitForSourceMapSources(script.source).then(sources =>
+      sources.length && this._scriptWithSourceMapHandler
+        ? this._scriptWithSourceMapHandler(script, sources)
+        : { remainPaused: false }
+    );
+
+    this._sourceMapLoads.set(script.scriptId, result);
+    return result;
   }
 
   async _revealObject(object: Cdp.Runtime.RemoteObject) {

--- a/src/adapter/threads.ts
+++ b/src/adapter/threads.ts
@@ -883,6 +883,7 @@ export class Thread implements VariableStoreDelegate {
     const timeout = this._sourceContainer.sourceMapTimeouts().scriptPaused;
     const script = this._scripts.get(scriptId);
     if (!script) {
+      this._pausedForSourceMapScriptId = undefined;
       return false;
     }
 

--- a/src/build/generate-contributions.ts
+++ b/src/build/generate-contributions.ts
@@ -81,6 +81,11 @@ const baseConfigurationAttributes: ConfigurationAttributes<IBaseConfiguration> =
       type: 'string',
     },
   },
+  pauseForSourceMap: {
+    type: 'boolean',
+    markdownDescription: refString('node.pauseForSourceMap.description'),
+    default: false,
+  },
   showAsyncStacks: {
     type: 'boolean',
     description: refString('node.showAsyncStacks.description'),

--- a/src/build/strings.ts
+++ b/src/build/strings.ts
@@ -74,6 +74,7 @@ const strings = {
     'Command to run in the launched terminal. If not provided, the terminal will open without launching a program.',
   'debug.terminal.snippet.label': 'Run "npm start" in a debug terminal',
 
+  'node.pauseForSourceMap.description': 'Whether to wait for source maps to load for each incoming script. This has a performance overhead, and might be safely disabled when running off of disk, so long as `rootPath` is not disabled.',
   'node.address.description': "TCP/IP address of process to be debugged. Default is 'localhost'.",
   'node.attach.config.name': 'Attach',
   'node.attach.processId.description': 'ID of process to attach to.',

--- a/src/common/logging/fileLogSink.ts
+++ b/src/common/logging/fileLogSink.ts
@@ -32,7 +32,7 @@ export class FileLogSink implements ILogSink {
       // already exists
     }
 
-    this.stream = createWriteStream(file, { flags: 'a' });
+    this.stream = createWriteStream(file);
   }
 
   /**

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -75,6 +75,12 @@ export interface IBaseConfiguration extends IMandatedConfiguration, Dap.LaunchPa
   resolveSourceMapLocations: ReadonlyArray<string> | null;
 
   /**
+   * Whether to pause when sourcemapped scripts are loaded to load their
+   * sourcemap and ensure breakpoints are set.
+   */
+  pauseForSourceMap: boolean;
+
+  /**
    * Show the async calls that led to the current call stack.
    */
   showAsyncStacks: boolean;
@@ -433,6 +439,7 @@ export const baseDefaults: IBaseConfiguration = {
   skipFiles: [],
   smartStep: true,
   sourceMaps: true,
+  pauseForSourceMap: true,
   resolveSourceMapLocations: null,
   rootPath: '${workspaceFolder}',
   // keep in sync with sourceMapPathOverrides in package.json


### PR DESCRIPTION
This PR fixes most of the the slow startup time while debugging VS Code.
Like I talked about at various points, the issue is that we have an
instrumentation breakpoint that asks the debugger to pause before we
load any sourcemapped script, so that we can ensure breakpoints get set.
For the large VS Code project, this slows things down a great deal.

If the breakpoint predictor is on and working for this workspace, this
actually isn't necessary--and fortunately, it does work for VS Code.
This PR adds an option that disables the runtime breakpoint once the
breakpoint predictor finishes up. This drops the boot time of the VS
Code debug launch from ~30s to ~6s on my machine, and performance
optimizations to the BreakpointPredictor will drop that further.

Right now this is somewhat of a special case. The breakpoint predictor
_should_ work well on _most_ Node.js apps and some Electron apps. It
might be possible to make the predictor smarter in the future.

Fixes https://github.com/microsoft/vscode-pwa/issues/99