### PR TITLE
Fix race condition in startup

### DIFF
--- a/src/adapter/breakpoints.ts
+++ b/src/adapter/breakpoints.ts
@@ -405,8 +405,8 @@ export class BreakpointManager {
       }
       return sources;
     });
-    for (const breakpoints of this._byPath.values()) breakpoints.forEach(b => b.set(thread));
-    for (const breakpoints of this._byRef.values()) breakpoints.forEach(b => b.set(thread));
+    for (const breakpoints of this._byPath.values()) breakpoints.forEach(b => this._setBreakpoint(b));
+    for (const breakpoints of this._byRef.values()) breakpoints.forEach(b => this._setBreakpoint(b));
     this._updateSourceMapHandler(this._thread);
   }
 
@@ -434,6 +434,10 @@ export class BreakpointManager {
     // once we see the predictor is ready to roll.
     await this._breakpointsPredictor.prepareToPredict();
     thread.setScriptSourceMapHandler(undefined);
+  }
+
+  private _setBreakpoint(b: Breakpoint): void {
+    this._launchBlocker = Promise.all([this._launchBlocker, b.set(this._thread!)]);
   }
 
   async setBreakpoints(
@@ -465,7 +469,7 @@ export class BreakpointManager {
     }
     this._totalBreakpointsCount += breakpoints.length;
     if (this._thread) {
-      breakpoints.forEach(b => b.set(this._thread!));
+      breakpoints.forEach(b => this._setBreakpoint(b));
     }
     const dapBreakpoints = breakpoints.map(b => b.toProvisionalDap());
     this._breakpointsStatisticsCalculator.registerBreakpoints(dapBreakpoints);

--- a/src/binder.ts
+++ b/src/binder.ts
@@ -202,7 +202,7 @@ export class Binder implements Disposable {
     const thread = debugAdapter.createThread(target.name(), cdp, target);
     this._threads.set(target, {thread, debugAdapter});
     const startThread = async () => {
-      await debugAdapter.breakpointManager.launchBlocker();
+      await debugAdapter.launchBlocker();
       cdp.Runtime.runIfWaitingForDebugger({});
       return {};
     };

--- a/src/common/promiseUtil.ts
+++ b/src/common/promiseUtil.ts
@@ -2,3 +2,22 @@
  * Returns a promise that resolves after the given time.
  */
 export const delay = (duration: number) => new Promise<void>(resolve => setTimeout(resolve, duration));
+
+export interface IDeferred<T> {
+  resolve: (result: T) => void;
+  reject: (err: Error) => void;
+  promise: Promise<T>;
+}
+
+export function getDeferred<T>(): IDeferred<T> {
+  let resolve: IDeferred<T>['resolve'] = null!;
+  let reject: IDeferred<T>['reject'] = null!;
+
+  // Promise constructor is called synchronously
+  const promise = new Promise<T>((_resolve, _reject) => {
+      resolve = _resolve;
+      reject = _reject;
+  });
+
+  return { resolve, reject, promise };
+}


### PR DESCRIPTION
Unless I'm misunderstanding something, I thing this is the right fix for #79. Now we will wait on the configurationDone event, and wait to finish setting the breakpoints that came at startup before configurationDone, before calling `runIfWaitingForDebugger`.