### PR TITLE
fix: call frame names appearing duplicated, `this` not appearing

### DIFF
--- a/src/adapter/stackTrace.ts
+++ b/src/adapter/stackTrace.ts
@@ -216,7 +216,7 @@ export class StackFrame {
       if (scope.name && scope.type === 'closure') {
         name = localize('scope.closureNamed', 'Closure ({0})', scope.name);
       } else if (scope.name) {
-        name = scope.name;
+        name = `${name}: ${scope.name}`;
       }
 
       const variable = await this._scopeVariable(scopeNumber);
@@ -289,7 +289,7 @@ export class StackFrame {
     if (!scope.variables[scopeNumber]) {
       const scopeRef: ScopeRef = { callFrameId: scope.callFrameId, scopeNumber };
       const extraProperties: ExtraProperty[] = [];
-      if (scopeNumber === 0 && scope.chain[scopeNumber].type === 'local') {
+      if (scopeNumber === 0) {
         extraProperties.push({name: 'this', value: scope.thisObject});
         if (scope.returnValue)
           extraProperties.push({name: localize('scope.returnValue', 'Return value'), value: scope.returnValue});

--- a/src/test/stacks/stacks-anonymous-scopes.txt
+++ b/src/test/stacks/stacks-anonymous-scopes.txt
@@ -1,12 +1,12 @@
 
 paused @ <eval>/VM<xx>:4:9
-  > scope #0: paused
+  > scope #0: Local: paused
       y: 'paused'
       > this: Window
   scope #1: Global [expensive]
 
 chained @ <eval>/VM<xx>:11:23
-  > scope #0: chained
+  > scope #0: Local: chained
       x: 'x1'
       > this: Window
   > scope #1: Closure (chain)
@@ -14,7 +14,7 @@ chained @ <eval>/VM<xx>:11:23
   scope #2: Global [expensive]
 
 chained @ <eval>/VM<xx>:11:23
-  > scope #0: chained
+  > scope #0: Local: chained
       x: 'x2'
       > this: Window
   > scope #1: Closure (chain)
@@ -22,7 +22,7 @@ chained @ <eval>/VM<xx>:11:23
   scope #2: Global [expensive]
 
 chained @ <eval>/VM<xx>:11:23
-  > scope #0: chained
+  > scope #0: Local: chained
       x: 'x3'
       > this: Window
   > scope #1: Closure (chain)

--- a/src/test/stacks/stacks-async-disables.txt
+++ b/src/test/stacks/stacks-async-disables.txt
@@ -1,12 +1,12 @@
 
 foo @ <eval>/VM<xx>:4:11
-  > scope #0: foo
+  > scope #0: Local: foo
       n: 0
       > this: Window
   scope #1: Global [expensive]
 
 bar @ <eval>/VM<xx>:13:15
-  > scope #0: bar
+  > scope #0: Local: bar
       n: 0
       > this: Window
   scope #1: Global [expensive]

--- a/src/test/stacks/stacks-async.txt
+++ b/src/test/stacks/stacks-async.txt
@@ -1,12 +1,12 @@
 
 foo @ <eval>/VM<xx>:4:11
-  > scope #0: foo
+  > scope #0: Local: foo
       n: 0
       > this: Window
   scope #1: Global [expensive]
 
 bar @ <eval>/VM<xx>:13:15
-  > scope #0: bar
+  > scope #0: Local: bar
       n: 0
       > this: Window
   scope #1: Global [expensive]

--- a/src/test/stacks/stacks-blackboxed.txt
+++ b/src/test/stacks/stacks-blackboxed.txt
@@ -1,2 +1,0 @@
-foo @ ${workspaceFolder}/web/browserify/module1.ts:3:2
-3../module1 @ ${workspaceFolder}/web/browserify/pause.ts:4:3

--- a/src/test/stacks/stacks-return-value.txt
+++ b/src/test/stacks/stacks-return-value.txt
@@ -1,6 +1,6 @@
 
 foo @ <eval>/VM<xx>:4:19
-  > scope #0: foo
+  > scope #0: Local: foo
       > this: Window
       Return value: 42
   scope #1: Global [expensive]

--- a/src/test/stacks/stacks-source-map.txt
+++ b/src/test/stacks/stacks-source-map.txt
@@ -1,11 +1,11 @@
 
 foo @ ${workspaceFolder}/web/browserify/module1.ts:3:2
-  > scope #0: foo
+  > scope #0: Local: foo
       this: undefined
   scope #1: Global [expensive]
 
 bar @ ${workspaceFolder}/web/browserify/module2.ts:3:2
-  > scope #0: bar
+  > scope #0: Local: bar
       
 > callback: ƒ foo() {
     debugger;
@@ -14,7 +14,7 @@ bar @ ${workspaceFolder}/web/browserify/module2.ts:3:2
   scope #1: Global [expensive]
 
 3../module1 @ ${workspaceFolder}/web/browserify/pause.ts:4:3
-  > scope #0: 3../module1
+  > scope #0: Local: 3../module1
       > exports: {__esModule: true}
       > m1: {__esModule: true, kModule1: 1, foo: ƒ, throwError: ƒ, throwValue: ƒ}
       > m2: {__esModule: true, kModule2: 2, bar: ƒ, pause: ƒ}
@@ -24,7 +24,7 @@ bar @ ${workspaceFolder}/web/browserify/module2.ts:3:2
   scope #1: Global [expensive]
 
 o @ ${workspaceFolder}/node_modules/browser-pack/_prelude.js:1:1
-  > scope #0: o
+  > scope #0: Local: o
       a: undefined
       c: undefined
       f: undefined
@@ -42,7 +42,7 @@ o @ ${workspaceFolder}/node_modules/browser-pack/_prelude.js:1:1
   scope #3: Global [expensive]
 
 r @ ${workspaceFolder}/node_modules/browser-pack/_prelude.js:1:1
-  > scope #0: r
+  > scope #0: Local: r
       > e: {1: Array(2), 2: Array(2), 3: Array(2)}
       i: 0
       > n: {1: {…}, 2: {…}, 3: {…}}

--- a/src/test/stacks/stacks-stack-in-eval.txt
+++ b/src/test/stacks/stacks-stack-in-eval.txt
@@ -1,1 +1,0 @@
-<anonymous> @ eval.js:3:1

--- a/src/test/variables/variables-setvariable-scope.txt
+++ b/src/test/variables/variables-setvariable-scope.txt
@@ -4,7 +4,7 @@ stopped: {
     reason : pause
     threadId : <number>
 }
-> scope: foo
+> scope: Local: foo
     y: 'value of y'
     z: 'value of z'
     > this: Window
@@ -13,7 +13,7 @@ Setting "y" to "z"
 <result>: 'value of z'
 
 Original
-> scope: foo
+> scope: Local: foo
     y: 'value of z'
     z: 'value of z'
     > this: Window


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode-pwa/issues/150

 - We always used the scope name as the reported name to VS Code,
   but there might be multiple scope names of different types.
 - Also in the issue, I noticed that `this` wasn't present. In the old
   adapters, we always add `this` to the top call scope. In PWA that
   was only happening if the top scope was `local` (and we never tried
   to add it anywhere if that wasn't the case). The most technically
   correct thing to do would be to show it at the nearest `local` scope,
   but I think showing it at the top is more useful and is what
   people are used to.

![image](https://user-images.githubusercontent.com/2230985/70189918-723b6280-16a9-11ea-9868-fa498d8b83e2.png)
