### PR TITLE
fix: source map override handling issues

### DIFF
--- a/src/baseConfigurationProvider.ts
+++ b/src/baseConfigurationProvider.ts
@@ -3,8 +3,14 @@
  *--------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { ResolvingConfiguration, AnyLaunchConfiguration } from './configuration';
+import {
+  ResolvingConfiguration,
+  AnyLaunchConfiguration,
+  IChromeBaseConfiguration,
+} from './configuration';
 import { fulfillLoggerOptions } from './common/logging';
+import { mapValues } from './common/objUtils';
+import { Contributions } from './common/contributionUtils';
 
 /**
  * Base configuration provider that handles some resolution around common
@@ -97,6 +103,16 @@ export abstract class BaseConfigurationProvider<T extends AnyLaunchConfiguration
   protected commonResolution(config: T): T {
     config.trace = fulfillLoggerOptions(config.trace, this.extensionContext.logPath);
     config.__workspaceCachePath = this.extensionContext.storagePath;
+
+    // The "${webRoot}" is not a standard vscode thing--replace it appropriately.
+    config.sourceMapPathOverrides = mapValues(config.sourceMapPathOverrides, value =>
+      value.replace(
+        '${webRoot}',
+        (config.type === Contributions.ChromeDebugType &&
+          (config as IChromeBaseConfiguration).webRoot) ||
+          '${workspaceFolder}',
+      ),
+    );
 
     return config;
   }

--- a/src/test/common/sourceMapOverrides.test.ts
+++ b/src/test/common/sourceMapOverrides.test.ts
@@ -34,6 +34,11 @@ describe('SourceMapOverrides', () => {
       const r = new SourceMapOverrides({ '/a/*': '/c', '/a/foo': '/b' });
       expect(r.apply('/a/foo')).to.equal('/b');
     });
+
+    it('normalizes mapped paths', () => {
+      const r = new SourceMapOverrides({ 'file:///./foo/*': '/b/*' });
+      expect(r.apply('file:///foo/bar')).to.equal('/b/bar');
+    });
   });
 
   describe('defaults', () => {


### PR DESCRIPTION
 - The previous adapter manually replaces[1] webRoot in the source map
   overrides. Do the same here for parity.
 - The `source-map` module normalizes URLs before they're given back to
   us, but the previous adapter didn't do this. Overrides that target
   prefixes like "webpack:///./*" don't work, because the extraneous
   "./" gets removed.

 1. https://github.com/microsoft/vscode-chrome-debug/blob/075b94d825294b5aa7992fee55125982ee44a669/src/chromeDebugAdapter.ts#L566

Fixes https://github.com/microsoft/vscode-pwa/issues/147
And most likely https://github.com/microsoft/vscode-pwa/issues/140